### PR TITLE
Set the last mount time using the realtime clock

### DIFF
--- a/fs/bcachefs/fifo.h
+++ b/fs/bcachefs/fifo.h
@@ -12,7 +12,9 @@ struct {								\
 #define DECLARE_FIFO(type, name)	FIFO(type) name
 
 #define fifo_buf_size(fifo)						\
-	(roundup_pow_of_two((fifo)->size) * sizeof((fifo)->data[0]))
+	((fifo)->size							\
+	 ? roundup_pow_of_two((fifo)->size) * sizeof((fifo)->data[0])	\
+	 : 0)
 
 #define init_fifo(fifo, _size, _gfp)					\
 ({									\

--- a/fs/bcachefs/super.c
+++ b/fs/bcachefs/super.c
@@ -686,7 +686,7 @@ const char *bch2_fs_start(struct bch_fs *c)
 	const char *err = "cannot allocate memory";
 	struct bch_sb_field_members *mi;
 	struct bch_dev *ca;
-	time64_t now = ktime_get_seconds();
+	time64_t now = ktime_get_real_seconds();
 	unsigned i;
 	int ret = -EINVAL;
 
@@ -1456,7 +1456,7 @@ have_slot:
 	/* success: */
 
 	mi->members[dev_idx] = dev_mi;
-	mi->members[dev_idx].last_mount = cpu_to_le64(ktime_get_seconds());
+	mi->members[dev_idx].last_mount = cpu_to_le64(ktime_get_real_seconds());
 	c->disk_sb.sb->nr_devices	= nr_devices;
 
 	ca->disk_sb.sb->dev_idx	= dev_idx;
@@ -1532,7 +1532,7 @@ int bch2_dev_online(struct bch_fs *c, const char *path)
 	mi = bch2_sb_get_members(c->disk_sb.sb);
 
 	mi->members[ca->dev_idx].last_mount =
-		cpu_to_le64(ktime_get_seconds());
+		cpu_to_le64(ktime_get_real_seconds());
 
 	bch2_write_super(c);
 	mutex_unlock(&c->sb_lock);


### PR DESCRIPTION
This way the last mount time is something meaningful like "Sun Nov  4 20:11:48 2018" instead of just being various times from 1970 (which happens with the monotonic clock since they have an unspecified start time).

Also, roundup_pow_of_two() is undefined when passed in 0, so check before calling it from fifo_buf_size().