### PR TITLE
Fix bkey_method compilation on gcc 7.3.0

### DIFF
--- a/fs/bcachefs/bkey_methods.c
+++ b/fs/bcachefs/bkey_methods.c
@@ -24,13 +24,13 @@ static const char *deleted_key_invalid(const struct bch_fs *c,
 	return NULL;
 }
 
-const struct bkey_ops bch2_bkey_ops_deleted = {
-	.key_invalid = deleted_key_invalid,
-};
+#define bch2_bkey_ops_deleted (struct bkey_ops) {	\
+	.key_invalid = deleted_key_invalid,		\
+}
 
-const struct bkey_ops bch2_bkey_ops_discard = {
-	.key_invalid = deleted_key_invalid,
-};
+#define bch2_bkey_ops_discard (struct bkey_ops) {	\
+	.key_invalid = deleted_key_invalid,		\
+}
 
 static const char *empty_val_key_invalid(const struct bch_fs *c, struct bkey_s_c k)
 {
@@ -40,9 +40,9 @@ static const char *empty_val_key_invalid(const struct bch_fs *c, struct bkey_s_c
 	return NULL;
 }
 
-const struct bkey_ops bch2_bkey_ops_error = {
-	.key_invalid = empty_val_key_invalid,
-};
+#define bch2_bkey_ops_error (struct bkey_ops) {		\
+	.key_invalid = empty_val_key_invalid,		\
+}
 
 static const char *key_type_cookie_invalid(const struct bch_fs *c,
 					   struct bkey_s_c k)
@@ -53,13 +53,13 @@ static const char *key_type_cookie_invalid(const struct bch_fs *c,
 	return NULL;
 }
 
-const struct bkey_ops bch2_bkey_ops_cookie = {
-	.key_invalid = key_type_cookie_invalid,
-};
+#define bch2_bkey_ops_cookie (struct bkey_ops) {	\
+	.key_invalid = key_type_cookie_invalid,		\
+}
 
-const struct bkey_ops bch2_bkey_ops_whiteout = {
-	.key_invalid = empty_val_key_invalid,
-};
+#define bch2_bkey_ops_whiteout (struct bkey_ops) {	\
+	.key_invalid = empty_val_key_invalid,		\
+}
 
 static const struct bkey_ops bch2_bkey_ops[] = {
 #define x(name, nr) [KEY_TYPE_##name]	= bch2_bkey_ops_##name,


### PR DESCRIPTION
bkey_methods.c currently fails to compile on GCC 7.3.0 (Ubuntu 18.04).

It looks like the const objects aren't considered valid const initializers for the const bch2_bkey_ops array.  This commit changes the const objects to #defines.

> fs/bcachefs/bkey_methods.c:65:41: error: initializer element is not constant
>  #define x(name, nr) [KEY_TYPE_##name] = bch2_bkey_ops_##name,
>                                          ^
> fs/bcachefs/bcachefs_format.h:323:2: note: in expansion of macro ‘x’
>   x(deleted,  0)   \
>   ^
> fs/bcachefs/bkey_methods.c:66:2: note: in expansion of macro ‘BCH_BKEY_TYPES’
>   BCH_BKEY_TYPES()
>   ^~~~~~~~~~~~~~
> fs/bcachefs/bkey_methods.c:65:41: note: (near initialization for ‘bch2_bkey_ops[0]’)
>  #define x(name, nr) [KEY_TYPE_##name] = bch2_bkey_ops_##name,
>                                          ^
> ...

Note: this also affects the current master on bcachefs-tools.