### PR TITLE
Blind fix for #111

### DIFF
--- a/fs/bcachefs/fs-io.c
+++ b/fs/bcachefs/fs-io.c
@@ -845,7 +845,7 @@ retry:
 		sectors = k.k->size - offset_into_extent;
 
 		ret = bch2_read_indirect_extent(trans,
-					&offset_into_extent, sk.k);
+					&offset_into_extent, &sk);
 		if (ret)
 			break;
 

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -889,7 +889,7 @@ retry:
 		sectors			= k.k->size - offset_into_extent;
 
 		ret = bch2_read_indirect_extent(&trans,
-					&offset_into_extent, cur.k);
+					&offset_into_extent, &cur);
 		if (ret)
 			break;
 

--- a/fs/bcachefs/io.c
+++ b/fs/bcachefs/io.c
@@ -1641,7 +1641,7 @@ retry:
 		sectors = k.k->size - offset_into_extent;
 
 		ret = bch2_read_indirect_extent(&trans,
-					&offset_into_extent, sk.k);
+					&offset_into_extent, &sk);
 		if (ret)
 			break;
 
@@ -1943,14 +1943,14 @@ static void bch2_read_endio(struct bio *bio)
 
 int __bch2_read_indirect_extent(struct btree_trans *trans,
 				unsigned *offset_into_extent,
-				struct bkey_i *orig_k)
+				struct bkey_on_stack *orig_k)
 {
 	struct btree_iter *iter;
 	struct bkey_s_c k;
 	u64 reflink_offset;
 	int ret;
 
-	reflink_offset = le64_to_cpu(bkey_i_to_reflink_p(orig_k)->v.idx) +
+	reflink_offset = le64_to_cpu(bkey_i_to_reflink_p(orig_k->k)->v.idx) +
 		*offset_into_extent;
 
 	iter = bch2_trans_get_iter(trans, BTREE_ID_REFLINK,
@@ -1973,7 +1973,7 @@ int __bch2_read_indirect_extent(struct btree_trans *trans,
 	}
 
 	*offset_into_extent = iter->pos.offset - bkey_start_offset(k.k);
-	bkey_reassemble(orig_k, k);
+	bkey_on_stack_reassemble(orig_k, trans->c, k);
 err:
 	bch2_trans_iter_put(trans, iter);
 	return ret;
@@ -2273,7 +2273,7 @@ retry:
 		k = bkey_i_to_s_c(sk.k);
 
 		ret = bch2_read_indirect_extent(&trans,
-					&offset_into_extent, sk.k);
+					&offset_into_extent, &sk);
 		if (ret)
 			goto err;
 

--- a/fs/bcachefs/io.h
+++ b/fs/bcachefs/io.h
@@ -3,6 +3,7 @@
 #define _BCACHEFS_IO_H
 
 #include "checksum.h"
+#include "bkey_on_stack.h"
 #include "io_types.h"
 
 #define to_wbio(_bio)			\
@@ -110,13 +111,13 @@ struct cache_promote_op;
 struct extent_ptr_decoded;
 
 int __bch2_read_indirect_extent(struct btree_trans *, unsigned *,
-				struct bkey_i *);
+				struct bkey_on_stack *);
 
 static inline int bch2_read_indirect_extent(struct btree_trans *trans,
 					    unsigned *offset_into_extent,
-					    struct bkey_i *k)
+					    struct bkey_on_stack *k)
 {
-	return k->k.type == KEY_TYPE_reflink_p
+	return k->k->k.type == KEY_TYPE_reflink_p
 		? __bch2_read_indirect_extent(trans, offset_into_extent, k)
 		: 0;
 }


### PR DESCRIPTION
I made this fix just by looking at the KASan report without knowing any of the bcachefs internals. Therefore this is probably not the right fix.


When a bkey_on_stack is passed to bch_read_indirect_extent, there is no
guarantee that it will be big enough to hold the bkey. And
bch_read_indirect_extent is not aware of bkey_on_stack to call realloc
on it. This cause a stack corruption.
