### PR TITLE
bcachefs: Fix out of bounds read in fs usage ioctl

### DIFF
--- a/fs/bcachefs/chardev.c
+++ b/fs/bcachefs/chardev.c
@@ -414,7 +414,8 @@ static long bch2_ioctl_fs_usage(struct bch_fs *c,
 		struct bch_replicas_entry *src_e =
 			cpu_replicas_entry(&c->replicas, i);
 
-		if (replicas_usage_next(dst_e) > dst_end) {
+		/* check that we have enough space for one replicas entry */
+		if (dst_e + 1 > dst_end) {
 			ret = -ERANGE;
 			break;
 		}


### PR DESCRIPTION
Fix a possible read out of bounds if bch2_ioctl_fs_usage is called when
replica_entries_bytes is set to a value that is smaller than the size
of bch_replicas_usage.

Not sure if this is the best fix yet, but the reproducer no longer triggers
the out of bounds read.

Fixes: #219 