### PR TITLE
bcachefs: Fix possible null deref on mount

### DIFF
--- a/fs/bcachefs/super.c
+++ b/fs/bcachefs/super.c
@@ -110,7 +110,7 @@ struct bch_fs *bch2_dev_to_fs(dev_t dev)
 
 	list_for_each_entry(c, &bch_fs_list, list)
 		for_each_member_device_rcu(ca, c, i, NULL)
-			if (ca->disk_sb.bdev->bd_dev == dev) {
+			if (ca->disk_sb.bdev && ca->disk_sb.bdev->bd_dev == dev) {
 				closure_get(&c->cl);
 				goto found;
 			}


### PR DESCRIPTION
Ensure that the block device pointer in a superblock handle is not
null before dereferencing it in bch2_dev_to_fs. The block device pointer
may be null when mounting a new bcachefs filesystem given another mounted
bcachefs filesystem exists that has at least one device that is offline.

Fixes: #228 

Signed-off-by: Dan Robertson <dan@dlrobertson.com>