### PR TITLE
bcachefs: Fix null deref in bch2_ioctl_read_super

### DIFF
--- a/fs/bcachefs/chardev.c
+++ b/fs/bcachefs/chardev.c
@@ -523,7 +523,7 @@ static long bch2_ioctl_read_super(struct bch_fs *c,
 	ret = copy_to_user((void __user *)(unsigned long)arg.sb,
 			   sb, vstruct_bytes(sb));
 err:
-	if (ca)
+	if (!IS_ERR_OR_NULL(ca))
 		percpu_ref_put(&ca->ref);
 	mutex_unlock(&c->sb_lock);
 	return ret;


### PR DESCRIPTION
Do not attempt to cleanup the returned value of bch2_device_lookup if
the returned value was an error pointer. We currently check to see if
the returned value is null and run the cleanup otherwise. As a result,
we attempt to run the cleanup on a error pointer.

Fixes: #227 

Signed-off-by: Dan Robertson <dan@dlrobertson.com>