### PR TITLE
bcachefs: avoid out-of-bounds in split_devs

### DIFF
--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -30,6 +30,7 @@
 #include <linux/posix_acl.h>
 #include <linux/random.h>
 #include <linux/statfs.h>
+#include <linux/string.h>
 #include <linux/xattr.h>
 
 static struct kmem_cache *bch2_inode_cache;
@@ -1310,6 +1311,9 @@ static char **split_devs(const char *_dev_name, unsigned *nr)
 {
 	char *dev_name = NULL, **devs = NULL, *s;
 	size_t i, nr_devs = 0;
+
+	if (strlen(_dev_name) == 0)
+		return NULL;
 
 	dev_name = kstrdup(_dev_name, GFP_KERNEL);
 	if (!dev_name)


### PR DESCRIPTION
```
bcachefs ~ # mount -t bcachefs "" /mnt/
mount: /mnt: mount(2) system call failed: Out of memory.
```
The ENOMEM comes from https://github.com/koverstreet/bcachefs/blob/master/fs/bcachefs/fs.c#L1491
Making that return a more appropriate error message is out of scope for this change.

Fixes #225 