### PR TITLE
bcachefs: properly initialize used values

### DIFF
--- a/fs/bcachefs/buckets.c
+++ b/fs/bcachefs/buckets.c
@@ -1642,8 +1642,8 @@ static int bch2_trans_mark_stripe(struct btree_trans *trans,
 				  struct bkey_s_c old, struct bkey_s_c new,
 				  unsigned flags)
 {
-	struct bkey_s_c_stripe old_s = { NULL };
-	struct bkey_s_c_stripe new_s = { NULL };
+	struct bkey_s_c_stripe old_s = { .k = NULL };
+	struct bkey_s_c_stripe new_s = { .k = NULL };
 	struct bch_replicas_padded r;
 	unsigned i;
 	int ret = 0;

--- a/fs/bcachefs/inode.c
+++ b/fs/bcachefs/inode.c
@@ -478,7 +478,7 @@ struct btree_iter *bch2_inode_create(struct btree_trans *trans,
 	struct btree_iter *iter = NULL;
 	struct bkey_s_c k;
 	u64 min, max, start, pos, *hint;
-	int ret;
+	int ret = 0;
 
 	u64 cpu = raw_smp_processor_id();
 	unsigned bits = (c->opts.inodes_32bit


### PR DESCRIPTION
 - Ensure the second key value in bch_hash_info is initialized to zero
   if the info type is of type BCH_STR_HASH_SIPHASH.

 - Initialize the possibly returned value in bch2_inode_create. Assuming
   bch2_btree_iter_peek returns bkey_s_c_null, the uninitialized value
   of ret could be returned to the user as an error pointer.

 - Fix compiler warning in initialization of bkey_s_c_stripe

fs/bcachefs/buckets.c:1646:35: warning: suggest braces around initialization
of subobject [-Wmissing-braces]
        struct bkey_s_c_stripe new_s = { NULL };
                                         ^~~~
Signed-off-by: Dan Robertson <dan@dlrobertson.com>