### PR TITLE
made changes to support clang, fixed a couple bugs

### DIFF
--- a/fs/bcachefs/bset.c
+++ b/fs/bcachefs/bset.c
@@ -1193,7 +1193,7 @@ static struct bkey_packed *bset_search_write_set(const struct btree *b,
 
 static inline void prefetch_four_cachelines(void *p)
 {
-#ifdef CONFIG_X86_64
+#if (CONFIG_X86_64 && !defined(__clang__))
 	asm(".intel_syntax noprefix;"
 	    "prefetcht0 [%0 - 127 + 64 * 0];"
 	    "prefetcht0 [%0 - 127 + 64 * 1];"

--- a/fs/bcachefs/btree_iter.c
+++ b/fs/bcachefs/btree_iter.c
@@ -1891,6 +1891,7 @@ static inline void bch2_btree_iter_init(struct btree_trans *trans,
 	iter->trans			= trans;
 	iter->uptodate			= BTREE_ITER_NEED_TRAVERSE;
 	iter->btree_id			= btree_id;
+	iter->real_pos			= POS_MIN;
 	iter->level			= 0;
 	iter->min_depth			= 0;
 	iter->locks_want		= 0;

--- a/fs/bcachefs/buckets.c
+++ b/fs/bcachefs/buckets.c
@@ -1797,7 +1797,7 @@ static int bch2_trans_mark_reflink_p(struct btree_trans *trans,
 	unsigned front_frag, back_frag;
 	s64 ret = 0;
 
-	sectors = abs(sectors);
+	sectors = llabs(sectors);
 	BUG_ON(offset + sectors > p.k->size);
 
 	front_frag = offset;

--- a/fs/bcachefs/io.c
+++ b/fs/bcachefs/io.c
@@ -120,7 +120,7 @@ void bch2_latency_acct(struct bch_dev *ca, u64 submit_time, int rw)
 		 * the time:
 		 */
 		if (abs((int) (old - io_latency)) < (old >> 1) &&
-		    now & ~(~0 << 5))
+		    now & ~(~0U << 5))
 			break;
 
 		new = ewma_add(old, io_latency, 5);


### PR DESCRIPTION
fs/bcachefs/bset.c      	edited prefetch macro to add clang support
fs/bcachefs/btree_iter.c 	bugfix: initialize iter->real_pos in bch2_btree_iter_init for later use
fs/bcachefs/buckets.c   	buxfix: changed abs()->llabs() for 64 bit argument
fs/bcachefs/io.c        	bugfix: eliminated undefined behavior (negative bitshift)