### PR TITLE
bcachefs: statfs resports incorrect avail blocks

### DIFF
--- a/fs/bcachefs/buckets.c
+++ b/fs/bcachefs/buckets.c
@@ -257,16 +257,9 @@ void bch2_fs_usage_to_text(struct printbuf *out,
 	}
 }
 
-#define RESERVE_FACTOR	6
-
 static u64 reserve_factor(u64 r)
 {
 	return r + (round_up(r, (1 << RESERVE_FACTOR)) >> RESERVE_FACTOR);
-}
-
-static u64 avail_factor(u64 r)
-{
-	return div_u64(r << RESERVE_FACTOR, (1 << RESERVE_FACTOR) + 1);
 }
 
 u64 bch2_fs_sectors_used(struct bch_fs *c, struct bch_fs_usage_online *fs_usage)

--- a/fs/bcachefs/buckets.h
+++ b/fs/bcachefs/buckets.h
@@ -294,6 +294,13 @@ static inline int bch2_disk_reservation_get(struct bch_fs *c,
 	return bch2_disk_reservation_add(c, res, sectors * nr_replicas, flags);
 }
 
+#define RESERVE_FACTOR	6
+
+static inline u64 avail_factor(u64 r)
+{
+	return div_u64(r << RESERVE_FACTOR, (1 << RESERVE_FACTOR) + 1);
+}
+
 int bch2_dev_buckets_resize(struct bch_fs *, struct bch_dev *, u64);
 void bch2_dev_buckets_free(struct bch_dev *);
 int bch2_dev_buckets_alloc(struct bch_fs *, struct bch_dev *);

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -1261,8 +1261,8 @@ static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)
 	buf->f_type	= BCACHEFS_STATFS_MAGIC;
 	buf->f_bsize	= sb->s_blocksize;
 	buf->f_blocks	= usage.capacity >> shift;
-	buf->f_bfree	= (usage.capacity - usage.used) >> shift;
-	buf->f_bavail	= buf->f_bfree;
+	buf->f_bfree	= usage.free >> shift;
+	buf->f_bavail	= avail_factor(usage.free) >> shift;
 
 	buf->f_files	= usage.nr_inodes + avail_inodes;
 	buf->f_ffree	= avail_inodes;


### PR DESCRIPTION
The current implementation of bch_statfs does not scale the number of
available blocks provided in f_bavail by the reserve factor. This causes
an allocation of a file of this size to fail. This is exercised in `generic/103`.

```
# ./check generic/103
[  128.075123] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): recovering from clean shutdown, journal seq 160
[  128.138161] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): going read-write
[  128.196547] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): mounted with opts: compression=gzip
FSTYP         -- bcachefs
PLATFORM      -- Linux/x86_64 bcachefs-debian 5.11.0+ #20 SMP Tue May 18 19:45:35 EDT 2021
MKFS_OPTIONS  -- --errors=panic /dev/loop2
MOUNT_OPTIONS -- /dev/loop2 /mnt/scratch

[  129.206259] bcachefs (loop2): recovering from clean shutdown, journal seq 4
[  129.214310] bcachefs (loop2): going read-write
[  129.242170] bcachefs (loop2): mounted with opts: errors=panic
[  129.504000] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): recovering from clean shutdown, journal seq 162
[  129.516822] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): going read-write
[  129.564122] bcachefs (856b630c-cb63-4803-9d73-5a6a0533349e): mounted with opts: compression=gzip
generic/103 3s ... [  129.718494] run fstests generic/103 at 2021-05-19 01:48:17
[  130.950722] bcachefs (loop2): recovering from clean shutdown, journal seq 4
[  130.957475] bcachefs (loop2): going read-write
[  130.979469] bcachefs (loop2): mounted with opts: errors=panic
[  132.486826] bcachefs (loop2): recovering from clean shutdown, journal seq 10
[  132.496627] bcachefs (loop2): going read-write
[  132.524348] bcachefs (loop2): mounted with opts: errors=panic
 3s
Ran: generic/103
Passed all 1 tests
```

Signed-off-by: Dan Robertson <dan@dlrobertson.com>