### PR TITLE
bcachefs: do not compile acl mod on minimal config

### DIFF
--- a/fs/bcachefs/Makefile
+++ b/fs/bcachefs/Makefile
@@ -2,7 +2,6 @@
 obj-$(CONFIG_BCACHEFS_FS)	+= bcachefs.o
 
 bcachefs-y		:=	\
-	acl.o			\
 	alloc_background.o	\
 	alloc_foreground.o	\
 	bkey.o			\
@@ -58,3 +57,5 @@ bcachefs-y		:=	\
 	util.o			\
 	varint.o		\
 	xattr.o
+
+bcachefs-$(CONFIG_BCACHEFS_POSIX_ACL) += acl.o

--- a/fs/bcachefs/xattr.c
+++ b/fs/bcachefs/xattr.c
@@ -560,8 +560,10 @@ static const struct xattr_handler bch_xattr_bcachefs_effective_handler = {
 
 const struct xattr_handler *bch2_xattr_handlers[] = {
 	&bch_xattr_user_handler,
+#ifdef CONFIG_BCACHEFS_POSIX_ACL
 	&posix_acl_access_xattr_handler,
 	&posix_acl_default_xattr_handler,
+#endif
 	&bch_xattr_trusted_handler,
 	&bch_xattr_security_handler,
 #ifndef NO_BCACHEFS_FS


### PR DESCRIPTION
Do not compile the acl.o target if BCACHEFS_POSIX_ACL is not enabled.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>