### PR TITLE
bcachefs: Fix unitialized use of a value

### DIFF
--- a/fs/bcachefs/replicas.c
+++ b/fs/bcachefs/replicas.c
@@ -435,6 +435,8 @@ static int __bch2_mark_bkey_replicas(struct bch_fs *c, struct bkey_s_c k,
 	unsigned i;
 	int ret;
 
+	memset(&search, 0, sizeof(search));
+
 	for (i = 0; i < cached.nr; i++) {
 		bch2_replicas_entry_cached(&search.e, cached.devs[i]);
 


### PR DESCRIPTION
Per Valgrind:
```
E           ==24412== Conditional jump or move depends on uninitialised value(s)
E           ==24412==    at 0x2BC70F: __bch2_mark_bkey_replicas (replicas.c:452)
E           ==24412==    by 0x2BC59A: bch2_bkey_replicas_marked (replicas.c:500)
```
which corresponds to:
```
             if (search.e.data_type == BCH_DATA_parity) {
```

initializing `search` at the beginning of the function satisfies the Valgrind `smoketest` in bcachefs-tools