### PR TITLE
bcachefs: mount: fix null deref with null devname

### DIFF
--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -1322,9 +1322,6 @@ static char **split_devs(const char *_dev_name, unsigned *nr)
 	char *dev_name = NULL, **devs = NULL, *s;
 	size_t i, nr_devs = 0;
 
-	if (strlen(_dev_name) == 0)
-		return NULL;
-
 	dev_name = kstrdup(_dev_name, GFP_KERNEL);
 	if (!dev_name)
 		return NULL;
@@ -1499,6 +1496,9 @@ static struct dentry *bch2_mount(struct file_system_type *fs_type,
 	ret = bch2_parse_mount_opts(NULL, &opts, data);
 	if (ret)
 		return ERR_PTR(ret);
+
+	if (!dev_name || strlen(dev_name) == 0)
+		return ERR_PTR(-EINVAL);
 
 	devs = split_devs(dev_name, &nr_devs);
 	if (!devs)


### PR DESCRIPTION
 - Fix null deref on mount when given a null device name.
 - Move the dev_name checks to return EINVAL when it is invalid.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>