### PR TITLE
fix a possible bcachefs checksum mapping error

### DIFF
--- a/fs/bcachefs/super-io.c
+++ b/fs/bcachefs/super-io.c
@@ -680,7 +680,7 @@ static void write_one_super(struct bch_fs *c, struct bch_dev *ca, unsigned idx)
 
 	sb->offset = sb->layout.sb_offset[idx];
 
-	SET_BCH_SB_CSUM_TYPE(sb, c->opts.metadata_checksum);
+	SET_BCH_SB_CSUM_TYPE(sb, bch2_csum_opt_to_type(c->opts.metadata_checksum, false));
 	sb->csum = csum_vstruct(c, BCH_SB_CSUM_TYPE(sb),
 				null_nonce(), sb);
 


### PR DESCRIPTION
fix a possible bcachefs checksum mapping error

This fixes some rare cases where the metadata checksum option specified may map to the wrong actual checksum type.

Signed-Off By: Janpieter Sollie <janpieter.sollie@edpnet.be>