### PR TITLE
bcachefs: ensure iter->should_be_locked is set

### DIFF
--- a/fs/bcachefs/ec.c
+++ b/fs/bcachefs/ec.c
@@ -863,7 +863,8 @@ static int ec_stripe_update_ptrs(struct bch_fs *c,
 		extent_stripe_ptr_add(e, s, ec_ptr, block);
 
 		bch2_btree_iter_set_pos(iter, bkey_start_pos(&sk.k->k));
-		ret   = bch2_trans_update(&trans, iter, sk.k, 0) ?:
+		ret   = bch2_btree_iter_traverse(iter) ?:
+			bch2_trans_update(&trans, iter, sk.k, 0) ?:
 			bch2_trans_commit(&trans, NULL, NULL,
 					BTREE_INSERT_NOFAIL);
 		if (ret == -EINTR)


### PR DESCRIPTION
Ensure that iter->should_be_locked value is set to true before we
call bch2_trans_update in ec_stripe_update_ptrs.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>