### PR TITLE
prepare checksum.c for more advanced algorithms

### DIFF
--- a/fs/bcachefs/Kconfig
+++ b/fs/bcachefs/Kconfig
@@ -20,6 +20,7 @@ config BCACHEFS_FS
 	select SIXLOCKS
 	select RAID6_PQ
 	select XOR_BLOCKS
+	select XXHASH
 	select SRCU
 	help
 	The bcachefs filesystem - a modern, copy on write filesystem, with

--- a/fs/bcachefs/bcachefs_format.h
+++ b/fs/bcachefs/bcachefs_format.h
@@ -1456,7 +1456,8 @@ enum bch_csum_type {
 	BCH_CSUM_CHACHA20_POLY1305_128	= 4,
 	BCH_CSUM_CRC32C			= 5,
 	BCH_CSUM_CRC64			= 6,
-	BCH_CSUM_NR			= 7,
+	BCH_CSUM_XXHASH			= 7,
+	BCH_CSUM_NR			= 8,
 };
 
 static const unsigned bch_crc_bytes[] = {
@@ -1465,6 +1466,7 @@ static const unsigned bch_crc_bytes[] = {
 	[BCH_CSUM_CRC32C]			= 4,
 	[BCH_CSUM_CRC64_NONZERO]		= 8,
 	[BCH_CSUM_CRC64]			= 8,
+	[BCH_CSUM_XXHASH]			= 8,
 	[BCH_CSUM_CHACHA20_POLY1305_80]		= 10,
 	[BCH_CSUM_CHACHA20_POLY1305_128]	= 16,
 };
@@ -1483,7 +1485,8 @@ static inline _Bool bch2_csum_type_is_encryption(enum bch_csum_type type)
 #define BCH_CSUM_OPTS()			\
 	x(none,			0)	\
 	x(crc32c,		1)	\
-	x(crc64,		2)
+	x(crc64,		2)	\
+	x(xxhash,		3)
 
 enum bch_csum_opts {
 #define x(t, n) BCH_CSUM_OPT_##t = n,

--- a/fs/bcachefs/bcachefs_format.h
+++ b/fs/bcachefs/bcachefs_format.h
@@ -1457,7 +1457,8 @@ enum bch_csum_type {
 	BCH_CSUM_CRC32C			= 5,
 	BCH_CSUM_CRC64			= 6,
 	BCH_CSUM_XXHASH			= 7,
-	BCH_CSUM_NR			= 8,
+	BCH_CSUM_XOR			= 8,
+	BCH_CSUM_NR			= 9,
 };
 
 static const unsigned bch_crc_bytes[] = {
@@ -1467,6 +1468,7 @@ static const unsigned bch_crc_bytes[] = {
 	[BCH_CSUM_CRC64_NONZERO]		= 8,
 	[BCH_CSUM_CRC64]			= 8,
 	[BCH_CSUM_XXHASH]			= 8,
+	[BCH_CSUM_XOR]				= 8,
 	[BCH_CSUM_CHACHA20_POLY1305_80]		= 10,
 	[BCH_CSUM_CHACHA20_POLY1305_128]	= 16,
 };
@@ -1486,7 +1488,8 @@ static inline _Bool bch2_csum_type_is_encryption(enum bch_csum_type type)
 	x(none,			0)	\
 	x(crc32c,		1)	\
 	x(crc64,		2)	\
-	x(xxhash,		3)
+	x(xxhash,		3)	\
+	x(xor64,		4)
 
 enum bch_csum_opts {
 #define x(t, n) BCH_CSUM_OPT_##t = n,

--- a/fs/bcachefs/checksum.c
+++ b/fs/bcachefs/checksum.c
@@ -6,6 +6,7 @@
 
 #include <linux/crc32c.h>
 #include <linux/crypto.h>
+#include <linux/xxhash.h>
 #include <linux/key.h>
 #include <linux/random.h>
 #include <linux/scatterlist.h>
@@ -26,6 +27,7 @@
 struct bch2_checksum_state {
 	union {
 		u64 seed;
+		struct xxh64_state h64state;
 	};
 	unsigned int type;
 };
@@ -44,6 +46,9 @@ static void bch2_checksum_init(struct bch2_checksum_state *state)
 	case BCH_CSUM_CRC64_NONZERO:
 		state->seed = U64_MAX;
 		break;
+	case BCH_CSUM_XXHASH:
+		xxh64_reset(&state->h64state, 0);
+		break;
 	default:
 		BUG();
 	}
@@ -56,6 +61,8 @@ static u64 bch2_checksum_final(const struct bch2_checksum_state *state)
 	case BCH_CSUM_CRC32C:
 	case BCH_CSUM_CRC64:
 		return state->seed;
+	case BCH_CSUM_XXHASH:
+		return xxh64_digest(&state->h64state);
 	case BCH_CSUM_CRC32C_NONZERO:
 		return state->seed ^ U32_MAX;
 	case BCH_CSUM_CRC64_NONZERO:
@@ -77,6 +84,9 @@ static void bch2_checksum_update(struct bch2_checksum_state *state, const void *
 	case BCH_CSUM_CRC64_NONZERO:
 	case BCH_CSUM_CRC64:
 		state->seed = crc64_be(state->seed, data, len);
+		break;
+	case BCH_CSUM_XXHASH:
+		xxh64_update(&state->h64state, data, len);
 		break;
 	default:
 		BUG();
@@ -155,6 +165,7 @@ struct bch_csum bch2_checksum(struct bch_fs *c, unsigned type,
 	case BCH_CSUM_CRC32C_NONZERO:
 	case BCH_CSUM_CRC64_NONZERO:
 	case BCH_CSUM_CRC32C:
+	case BCH_CSUM_XXHASH:
 	case BCH_CSUM_CRC64: {
 		struct bch2_checksum_state state;
 
@@ -206,6 +217,7 @@ static struct bch_csum __bch2_checksum_bio(struct bch_fs *c, unsigned type,
 	case BCH_CSUM_CRC32C_NONZERO:
 	case BCH_CSUM_CRC64_NONZERO:
 	case BCH_CSUM_CRC32C:
+	case BCH_CSUM_XXHASH:
 	case BCH_CSUM_CRC64: {
 		struct bch2_checksum_state state;
 

--- a/fs/bcachefs/checksum.h
+++ b/fs/bcachefs/checksum.h
@@ -83,6 +83,8 @@ static inline enum bch_csum_type bch2_csum_opt_to_type(enum bch_csum_opts type,
 	     return data ? BCH_CSUM_CRC32C : BCH_CSUM_CRC32C_NONZERO;
 	case BCH_CSUM_OPT_crc64:
 	     return data ? BCH_CSUM_CRC64 : BCH_CSUM_CRC64_NONZERO;
+	case BCH_CSUM_OPT_xxhash:
+	     return BCH_CSUM_XXHASH;
 	default:
 	     BUG();
 	}

--- a/fs/bcachefs/checksum.h
+++ b/fs/bcachefs/checksum.h
@@ -14,6 +14,7 @@ static inline bool bch2_checksum_mergeable(unsigned type)
 
 	switch (type) {
 	case BCH_CSUM_NONE:
+	case BCH_CSUM_XOR:
 	case BCH_CSUM_CRC32C:
 	case BCH_CSUM_CRC64:
 		return true;
@@ -85,6 +86,8 @@ static inline enum bch_csum_type bch2_csum_opt_to_type(enum bch_csum_opts type,
 	     return data ? BCH_CSUM_CRC64 : BCH_CSUM_CRC64_NONZERO;
 	case BCH_CSUM_OPT_xxhash:
 	     return BCH_CSUM_XXHASH;
+	case BCH_CSUM_OPT_xor64:
+	     return BCH_CSUM_XOR;
 	default:
 	     BUG();
 	}


### PR DESCRIPTION
Current checksum implementation allows only checksums having their state stored into a u64 value, which is pretty limited.
This patch makes sure more advanced hashing algorithms can be used instead of crc32 / 64