### PR TITLE
bcachefs: statfs bfree and bavail should be the same

### DIFF
--- a/fs/bcachefs/btree_gc.c
+++ b/fs/bcachefs/btree_gc.c
@@ -333,8 +333,10 @@ again:
 			continue;
 		}
 
-		if (prev)
+		if (prev) {
 			six_unlock_read(&prev->c.lock);
+			prev = NULL;
+		}
 
 		if (ret == DROP_PREV_NODE) {
 			bch2_btree_node_evict(c, prev_k.k);

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -1274,8 +1274,8 @@ static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)
 	buf->f_type	= BCACHEFS_STATFS_MAGIC;
 	buf->f_bsize	= sb->s_blocksize;
 	buf->f_blocks	= usage.capacity >> shift;
-	buf->f_bfree	= usage.free >> shift;
-	buf->f_bavail	= avail_factor(usage.free) >> shift;
+	buf->f_bfree	= avail_factor(usage.free) >> shift;
+	buf->f_bavail	= buf->f_bfree;
 
 	buf->f_files	= usage.nr_inodes + avail_inodes;
 	buf->f_ffree	= avail_inodes;


### PR DESCRIPTION
The value of f_bfree and f_bavail should be the same. The value of
f_bfree is not currently scaled by the availability factor.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>