### PR TITLE
bcachefs: Fix bch2_acl_chmod() cleanup on error

### DIFF
--- a/fs/bcachefs/acl.c
+++ b/fs/bcachefs/acl.c
@@ -370,7 +370,7 @@ int bch2_acl_chmod(struct btree_trans *trans,
 	acl = bch2_acl_from_disk(xattr_val(xattr.v),
 			le16_to_cpu(xattr.v->x_val_len));
 	ret = PTR_ERR_OR_ZERO(acl);
-	if (ret || !acl)
+	if (IS_ERR_OR_NULL(acl))
 		goto err;
 
 	ret = __posix_acl_chmod(&acl, GFP_KERNEL, mode);
@@ -389,7 +389,8 @@ int bch2_acl_chmod(struct btree_trans *trans,
 	acl = NULL;
 err:
 	bch2_trans_iter_put(trans, iter);
-	kfree(acl);
+	if (!IS_ERR_OR_NULL(acl))
+		kfree(acl);
 	return ret;
 }
 


### PR DESCRIPTION
Avoid calling kfree on the returned error pointer if
bch2_acl_from_disk fails.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>