### PR TITLE
bcachefs: fix truncate without a size change

### DIFF
--- a/fs/bcachefs/fs-io.c
+++ b/fs/bcachefs/fs-io.c
@@ -2307,16 +2307,17 @@ int bch2_truncate(struct user_namespace *mnt_userns,
 	int ret = 0;
 
 	/*
-	 * Don't update timestamps if we're not doing anything:
+	 * If the truncate call with change the size of the file, the
+	 * cmtimes should be updated. If the size will not change, we
+	 * do not need to update the cmtimes.
 	 */
-	if (iattr->ia_size == inode->v.i_size)
-		return 0;
-
-	if (!(iattr->ia_valid & ATTR_MTIME))
-		ktime_get_coarse_real_ts64(&iattr->ia_mtime);
-	if (!(iattr->ia_valid & ATTR_CTIME))
-		ktime_get_coarse_real_ts64(&iattr->ia_ctime);
-	iattr->ia_valid |= ATTR_MTIME|ATTR_CTIME;
+	if (iattr->ia_size != inode->v.i_size) {
+		if (!(iattr->ia_valid & ATTR_MTIME))
+			ktime_get_coarse_real_ts64(&iattr->ia_mtime);
+		if (!(iattr->ia_valid & ATTR_CTIME))
+			ktime_get_coarse_real_ts64(&iattr->ia_ctime);
+		iattr->ia_valid |= ATTR_MTIME|ATTR_CTIME;
+	}
 
 	inode_dio_wait(&inode->v);
 	bch2_pagecache_block_get(&inode->ei_pagecache_lock);


### PR DESCRIPTION
Do not attempt to shortcut a truncate when the given new size is
the same as the current size. There may be blocks allocated to the
file that extend beyond the i_size.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>


Fixes: #270 