### PR TITLE
bcachefs: ensure iter->should_be_locked is set

### DIFF
--- a/fs/bcachefs/migrate.c
+++ b/fs/bcachefs/migrate.c
@@ -73,7 +73,8 @@ static int __bch2_dev_usrdata_drop(struct bch_fs *c, unsigned dev_idx, int flags
 
 		bch2_btree_iter_set_pos(iter, bkey_start_pos(&sk.k->k));
 
-		ret   = bch2_trans_update(&trans, iter, sk.k, 0) ?:
+		ret   = bch2_btree_iter_traverse(iter) ?:
+			bch2_trans_update(&trans, iter, sk.k, 0) ?:
 			bch2_trans_commit(&trans, NULL, NULL,
 					BTREE_INSERT_NOFAIL);
 


### PR DESCRIPTION
Ensure that iter->should_be_locked is set to true before we
call bch2_trans_update in __bch2_dev_usrdata_drop.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>