### PR TITLE
bcachefs: fix ifdef for x86_64 asm

### DIFF
--- a/fs/bcachefs/bset.c
+++ b/fs/bcachefs/bset.c
@@ -1193,7 +1193,7 @@ static struct bkey_packed *bset_search_write_set(const struct btree *b,
 
 static inline void prefetch_four_cachelines(void *p)
 {
-#if CONFIG_X86_64
+#ifdef CONFIG_X86_64
 	asm("prefetcht0 (-127 + 64 * 0)(%0);"
 	    "prefetcht0 (-127 + 64 * 1)(%0);"
 	    "prefetcht0 (-127 + 64 * 2)(%0);"


### PR DESCRIPTION
The implementation of prefetch_four_cachelines should use ifdef
CONFIG_X86_64 to conditionally compile x86_64 asm.

Signed-off-by: Dan Robertson <dan@dlrobertson.com>