### PR TITLE
bcachefs: rewrote XOR checksum support

### DIFF
--- a/fs/bcachefs/bcachefs_format.h
+++ b/fs/bcachefs/bcachefs_format.h
@@ -1458,7 +1458,8 @@ enum bch_csum_type {
 	BCH_CSUM_CRC32C			= 5,
 	BCH_CSUM_CRC64			= 6,
 	BCH_CSUM_XXHASH			= 7,
-	BCH_CSUM_NR			= 8,
+	BCH_CSUM_XOR			= 8,
+	BCH_CSUM_NR			= 9,
 };
 
 static const unsigned bch_crc_bytes[] = {
@@ -1468,6 +1469,7 @@ static const unsigned bch_crc_bytes[] = {
 	[BCH_CSUM_CRC64_NONZERO]		= 8,
 	[BCH_CSUM_CRC64]			= 8,
 	[BCH_CSUM_XXHASH]			= 8,
+	[BCH_CSUM_XOR]				= 8,
 	[BCH_CSUM_CHACHA20_POLY1305_80]		= 10,
 	[BCH_CSUM_CHACHA20_POLY1305_128]	= 16,
 };
@@ -1487,7 +1489,8 @@ static inline _Bool bch2_csum_type_is_encryption(enum bch_csum_type type)
 	x(none,			0)	\
 	x(crc32c,		1)	\
 	x(crc64,		2)	\
-	x(xxhash,		3)
+	x(xxhash,		3)	\
+	x(xor,			4)
 
 enum bch_csum_opts {
 #define x(t, n) BCH_CSUM_OPT_##t = n,

--- a/fs/bcachefs/checksum.h
+++ b/fs/bcachefs/checksum.h
@@ -16,6 +16,7 @@ static inline bool bch2_checksum_mergeable(unsigned type)
 	case BCH_CSUM_NONE:
 	case BCH_CSUM_CRC32C:
 	case BCH_CSUM_CRC64:
+	case BCH_CSUM_XOR:
 		return true;
 	default:
 		return false;
@@ -85,6 +86,8 @@ static inline enum bch_csum_type bch2_csum_opt_to_type(enum bch_csum_opts type,
 	     return data ? BCH_CSUM_CRC64 : BCH_CSUM_CRC64_NONZERO;
 	case BCH_CSUM_OPT_xxhash:
 	     return BCH_CSUM_XXHASH;
+	case BCH_CSUM_OPT_xor:
+	     return BCH_CSUM_XOR;
 	default:
 	     BUG();
 	}


### PR DESCRIPTION
Second proposal for faster checksumming,
without dynamic memory allocation.
XOR can be used to provide a performance bump + is mergeable.
This, is not considered 'safe' for large blocks.
The checksum is calculated on a 8-byte (64-bit) base,
the probability of a collision is a little less (1/64),
but it stays a checksum focused on speed, not on reliability.

Signed-off-by: jpsollie <janpieter.sollie@edpnet.be>