### PR TITLE
export data movement stats to sysfs

### DIFF
--- a/fs/bcachefs/bcachefs.h
+++ b/fs/bcachefs/bcachefs.h
@@ -791,6 +791,10 @@ struct bch_fs {
 	struct write_point	copygc_write_point;
 	s64			copygc_wait;
 
+	/* DATA PROGRESS STATS */
+	struct list_head	data_progress_list;
+	struct mutex		data_progress_lock;
+
 	/* STRIPES: */
 	GENRADIX(struct stripe) stripes[2];
 

--- a/fs/bcachefs/move.c
+++ b/fs/bcachefs/move.c
@@ -686,6 +686,30 @@ out:
 	return ret;
 }
 
+inline void bch_move_stats_init(struct bch_move_stats *stats, char *name)
+{
+	memset(stats, 0, sizeof(*stats));
+
+	scnprintf(stats->name, sizeof(stats->name),
+			"%s", name);
+}
+
+static inline void progress_list_add(struct bch_fs *c,
+				     struct bch_move_stats *stats)
+{
+	mutex_lock(&c->data_progress_lock);
+	list_add(&stats->list, &c->data_progress_list);
+	mutex_unlock(&c->data_progress_lock);
+}
+
+static inline void progress_list_del(struct bch_fs *c,
+				     struct bch_move_stats *stats)
+{
+	mutex_lock(&c->data_progress_lock);
+	list_del(&stats->list);
+	mutex_unlock(&c->data_progress_lock);
+}
+
 int bch2_move_data(struct bch_fs *c,
 		   enum btree_id start_btree_id, struct bpos start_pos,
 		   enum btree_id end_btree_id,   struct bpos end_pos,
@@ -698,6 +722,7 @@ int bch2_move_data(struct bch_fs *c,
 	enum btree_id id;
 	int ret;
 
+	progress_list_add(c, stats);
 	closure_init_stack(&ctxt.cl);
 	INIT_LIST_HEAD(&ctxt.reads);
 	init_waitqueue_head(&ctxt.wait);
@@ -731,6 +756,7 @@ int bch2_move_data(struct bch_fs *c,
 			atomic64_read(&stats->sectors_moved),
 			atomic64_read(&stats->keys_moved));
 
+	progress_list_del(c, stats);
 	return ret;
 }
 
@@ -755,6 +781,7 @@ static int bch2_move_btree(struct bch_fs *c,
 	int ret = 0;
 
 	bch2_trans_init(&trans, c, 0, 0);
+	progress_list_add(c, stats);
 
 	stats->data_type = BCH_DATA_btree;
 
@@ -803,6 +830,7 @@ next:
 	if (ret)
 		bch_err(c, "error %i in bch2_move_btree", ret);
 
+	progress_list_del(c, stats);
 	return ret;
 }
 
@@ -944,6 +972,7 @@ int bch2_data_job(struct bch_fs *c,
 
 	switch (op.op) {
 	case BCH_DATA_OP_REREPLICATE:
+		bch_move_stats_init(stats, "rereplicate");
 		stats->data_type = BCH_DATA_journal;
 		ret = bch2_journal_flush_device_pins(&c->journal, -1);
 
@@ -968,6 +997,7 @@ int bch2_data_job(struct bch_fs *c,
 		if (op.migrate.dev >= c->sb.nr_devices)
 			return -EINVAL;
 
+		bch_move_stats_init(stats, "migrate");
 		stats->data_type = BCH_DATA_journal;
 		ret = bch2_journal_flush_device_pins(&c->journal, op.migrate.dev);
 
@@ -985,6 +1015,7 @@ int bch2_data_job(struct bch_fs *c,
 		ret = bch2_replicas_gc2(c) ?: ret;
 		break;
 	case BCH_DATA_OP_REWRITE_OLD_NODES:
+		bch_move_stats_init(stats, "rewrite_old_nodes");
 		ret = bch2_scan_old_btree_nodes(c, stats);
 		break;
 	default:

--- a/fs/bcachefs/move.h
+++ b/fs/bcachefs/move.h
@@ -66,4 +66,8 @@ int bch2_data_job(struct bch_fs *,
 		  struct bch_move_stats *,
 		  struct bch_ioctl_data);
 
+inline void bch_move_stats_init(struct bch_move_stats *stats,
+				char *name);
+
+
 #endif /* _BCACHEFS_MOVE_H */

--- a/fs/bcachefs/move_types.h
+++ b/fs/bcachefs/move_types.h
@@ -6,6 +6,8 @@ struct bch_move_stats {
 	enum bch_data_type	data_type;
 	enum btree_id		btree_id;
 	struct bpos		pos;
+	struct list_head	list;
+	char			name[32];
 
 	atomic64_t		keys_moved;
 	atomic64_t		keys_raced;

--- a/fs/bcachefs/movinggc.c
+++ b/fs/bcachefs/movinggc.c
@@ -147,7 +147,8 @@ static int bch2_copygc(struct bch_fs *c)
 	size_t b, heap_size = 0;
 	int ret;
 
-	memset(&move_stats, 0, sizeof(move_stats));
+	bch_move_stats_init(&move_stats, "copygc");
+
 	/*
 	 * Find buckets with lowest sector counts, skipping completely
 	 * empty buckets, by building a maxheap sorted by sector count,

--- a/fs/bcachefs/rebalance_types.h
+++ b/fs/bcachefs/rebalance_types.h
@@ -19,7 +19,6 @@ struct bch_fs_rebalance {
 	enum rebalance_state	state;
 	u64			throttled_until_iotime;
 	unsigned long		throttled_until_cputime;
-	struct bch_move_stats	move_stats;
 
 	unsigned		enabled:1;
 };

--- a/fs/bcachefs/recovery.c
+++ b/fs/bcachefs/recovery.c
@@ -1216,7 +1216,9 @@ use_clean:
 
 	if (!(c->sb.compat & (1ULL << BCH_COMPAT_extents_above_btree_updates_done)) ||
 	    !(c->sb.compat & (1ULL << BCH_COMPAT_bformat_overflow_done))) {
-		struct bch_move_stats stats = { 0 };
+		struct bch_move_stats stats;
+
+		bch_move_stats_init(&stats, "recovery");
 
 		bch_info(c, "scanning for old btree nodes");
 		ret = bch2_fs_read_write(c);

--- a/fs/bcachefs/super.c
+++ b/fs/bcachefs/super.c
@@ -704,6 +704,9 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	INIT_LIST_HEAD(&c->ec_stripe_new_list);
 	mutex_init(&c->ec_stripe_new_lock);
 
+	INIT_LIST_HEAD(&c->data_progress_list);
+	mutex_init(&c->data_progress_lock);
+
 	spin_lock_init(&c->ec_stripes_heap_lock);
 
 	seqcount_init(&c->gc_pos_lock);

--- a/fs/bcachefs/sysfs.c
+++ b/fs/bcachefs/sysfs.c
@@ -203,6 +203,8 @@ read_attribute(new_stripes);
 read_attribute(io_timers_read);
 read_attribute(io_timers_write);
 
+read_attribute(data_op_data_progress);
+
 #ifdef CONFIG_BCACHEFS_TESTS
 write_attribute(perf_test);
 #endif /* CONFIG_BCACHEFS_TESTS */
@@ -237,6 +239,37 @@ static size_t bch2_btree_avg_write_size(struct bch_fs *c)
 	u64 sectors = atomic64_read(&c->btree_writes_sectors);
 
 	return nr ? div64_u64(sectors, nr) : 0;
+}
+
+static long stats_to_text(struct printbuf *out, struct bch_fs *c,
+			  struct bch_move_stats *stats)
+{
+	pr_buf(out, "%s: data type %s btree_id %s position: ",
+		stats->name,
+		bch2_data_types[stats->data_type],
+		bch2_btree_ids[stats->btree_id]);
+	bch2_bpos_to_text(out, stats->pos);
+	pr_buf(out, "%s", "\n");
+
+	return 0;
+}
+
+static long data_progress_to_text(struct printbuf *out, struct bch_fs *c)
+{
+	long ret = 0;
+	struct bch_move_stats *iter;
+
+	mutex_lock(&c->data_progress_lock);
+
+	if (list_empty(&c->data_progress_list))
+		pr_buf(out, "%s", "no progress to report\n");
+	else
+		list_for_each_entry(iter, &c->data_progress_list, list) {
+			stats_to_text(out, c, iter);
+		}
+
+	mutex_unlock(&c->data_progress_lock);
+	return ret;
 }
 
 static int fs_alloc_debug_to_text(struct printbuf *out, struct bch_fs *c)
@@ -434,6 +467,11 @@ SHOW(bch2_fs)
 		return out.pos - buf;
 	}
 
+	if (attr == &sysfs_data_op_data_progress) {
+		data_progress_to_text(&out, c);
+		return out.pos - buf;
+	}
+
 	return 0;
 }
 
@@ -595,6 +633,8 @@ struct attribute *bch2_fs_internal_files[] = {
 
 	&sysfs_io_timers_read,
 	&sysfs_io_timers_write,
+
+	&sysfs_data_op_data_progress,
 
 	&sysfs_internal_uuid,
 	NULL


### PR DESCRIPTION
currently exported stats:
 	- copygc
	- rebalance
	- recovery
	- cmd_job ioctl stats