### PR TITLE
partially revert eliminate unneccessary preempt_disable

### DIFF
--- a/fs/bcachefs/util.c
+++ b/fs/bcachefs/util.c
@@ -887,8 +887,17 @@ void eytzinger0_find_test(void)
  */
 u64 *bch2_acc_percpu_u64s(u64 __percpu *p, unsigned nr)
 {
+#ifndef CONFIG_PREEMPT
 	u64 *ret = this_cpu_ptr(p);
 	int cpu;
+#else
+	u64 ret;
+	int cpu;
+
+	preempt_disable();
+	ret = this_cpu_ptr(p);
+	preempt_enable();
+#endif
 
 	for_each_possible_cpu(cpu) {
 		u64 *i = per_cpu_ptr(p, cpu);


### PR DESCRIPTION
commit 816303aa24ff98ec0b67805671d0b2f03ce898c8 introduces a problem with preemption,
resulting in a BUG() using smp_processor_id() in preemptible code
which can be solved by disabling preemption,
but only if the kernel has been compiled with preemption
fixes #295 

Signed-off-by: jpsollie <janpieter.sollie@edpnet.be>