### PR TITLE
Fix compiler warnings

### DIFF
--- a/fs/bcachefs/journal_reclaim.c
+++ b/fs/bcachefs/journal_reclaim.c
@@ -653,7 +653,7 @@ static int __bch2_journal_reclaim(struct journal *j, bool direct)
 				atomic_long_read(&c->btree_key_cache.nr_dirty),
 				atomic_long_read(&c->btree_key_cache.nr_keys));
 
-		min_key_cache = min(bch2_nr_btree_keys_need_flush(c), 128UL);
+		min_key_cache = min(bch2_nr_btree_keys_need_flush(c), (size_t) 128);
 
 		nr_flushed = journal_flush_pins(j, seq_to_flush,
 						min_nr, min_key_cache);

--- a/fs/bcachefs/subvolume.h
+++ b/fs/bcachefs/subvolume.h
@@ -75,7 +75,7 @@ static inline void snapshots_seen_init(struct snapshots_seen *s)
 static inline int snapshots_seen_add(struct bch_fs *c, struct snapshots_seen *s, u32 id)
 {
 	if (s->nr == s->size) {
-		size_t new_size = max(s->size, 128UL) * 2;
+		size_t new_size = max(s->size, (size_t) 128) * 2;
 		u32 *d = krealloc(s->d, new_size * sizeof(s->d[0]), GFP_KERNEL);
 
 		if (!d) {


### PR DESCRIPTION
Fixes this:
```
libbcachefs/journal_reclaim.c: In function ‘__bch2_journal_reclaim’:
include/linux/kernel.h:108:17: warning: comparison of distinct pointer types lacks a cast
  (void) (&_min1 == &_min2);  \
                 ^~
libbcachefs/journal_reclaim.c:656:19: note: in expansion of macro ‘min’
   min_key_cache = min(bch2_nr_btree_keys_need_flush(c), 128UL);
                   ^~~
```
And this:
```
libbcachefs/subvolume.h: In function ‘snapshots_seen_add’:
include/linux/kernel.h:102:17: warning: comparison of distinct pointer types lacks a cast
  (void) (&_max1 == &_max2);  \
                 ^~
libbcachefs/subvolume.h:78:21: note: in expansion of macro ‘max’
   size_t new_size = max(s->size, 128UL) * 2;
                     ^~~
```

Testing:

I verified warnings go away on on armv6l (Rpi 0 vm)
I started running some amd64 single disk ktests and nothing has complained yet.
