### PR TITLE
Partially re-enable the NFS filesystem structure

### DIFF
--- a/block/bio.c
+++ b/block/bio.c
@@ -1284,15 +1284,27 @@ EXPORT_SYMBOL(bio_advance);
 void bio_copy_data_iter(struct bio *dst, struct bvec_iter *dst_iter,
 			struct bio *src, struct bvec_iter *src_iter)
 {
-	while (src_iter->bi_size && dst_iter->bi_size) {
-		struct bio_vec src_bv = bio_iter_iovec(src, *src_iter);
-		struct bio_vec dst_bv = bio_iter_iovec(dst, *dst_iter);
-		unsigned int bytes = min(src_bv.bv_len, dst_bv.bv_len);
-		void *src_buf;
+	struct bio_vec src_bv, dst_bv;
+	void *src_p, *dst_p;
+	unsigned bytes;
 
-		src_buf = bvec_kmap_local(&src_bv);
-		memcpy_to_bvec(&dst_bv, src_buf);
-		kunmap_local(src_buf);
+	while (src_iter->bi_size && dst_iter->bi_size) {
+		src_bv = bio_iter_iovec(src, *src_iter);
+		dst_bv = bio_iter_iovec(dst, *dst_iter);
+
+		bytes = min(src_bv.bv_len, dst_bv.bv_len);
+
+		src_p = kmap_atomic(src_bv.bv_page);
+		dst_p = kmap_atomic(dst_bv.bv_page);
+
+		memcpy(dst_p + dst_bv.bv_offset,
+		       src_p + src_bv.bv_offset,
+		       bytes);
+
+		kunmap_atomic(dst_p);
+		kunmap_atomic(src_p);
+
+		flush_dcache_page(dst_bv.bv_page);
 
 		bio_advance_iter_single(src, src_iter, bytes);
 		bio_advance_iter_single(dst, dst_iter, bytes);

--- a/fs/bcachefs/acl.c
+++ b/fs/bcachefs/acl.c
@@ -331,8 +331,7 @@ retry:
 	inode_u.bi_mode		= mode;
 
 	ret =   bch2_inode_write(&trans, &inode_iter, &inode_u) ?:
-		bch2_trans_commit(&trans, NULL,
-				  &inode->ei_journal_seq, 0);
+		bch2_trans_commit(&trans, NULL, NULL, 0);
 btree_err:
 	bch2_trans_iter_exit(&trans, &inode_iter);
 

--- a/fs/bcachefs/acl.c
+++ b/fs/bcachefs/acl.c
@@ -340,7 +340,7 @@ btree_err:
 	if (unlikely(ret))
 		goto err;
 
-	bch2_inode_update_after_write(c, inode, &inode_u,
+	bch2_inode_update_after_write(&trans, inode, &inode_u,
 				      ATTR_CTIME|ATTR_MODE);
 
 	set_cached_acl(&inode->v, type, acl);

--- a/fs/bcachefs/btree_iter.c
+++ b/fs/bcachefs/btree_iter.c
@@ -49,7 +49,7 @@ static inline int __btree_path_cmp(const struct btree_path *l,
 				   unsigned		r_level)
 {
 	return   cmp_int(l->btree_id,	r_btree_id) ?:
-		 cmp_int(l->cached,	r_cached) ?:
+		 cmp_int((int) l->cached,	(int) r_cached) ?:
 		 bpos_cmp(l->pos,	r_pos) ?:
 		-cmp_int(l->level,	r_level);
 }
@@ -758,6 +758,43 @@ static int bch2_btree_iter_verify_ret(struct btree_iter *iter, struct bkey_s_c k
 out:
 	bch2_trans_iter_exit(trans, &copy);
 	return ret;
+}
+
+void bch2_assert_pos_locked(struct btree_trans *trans, enum btree_id id,
+			    struct bpos pos, bool key_cache)
+{
+	struct btree_path *path;
+	unsigned idx;
+	char buf[100];
+
+	trans_for_each_path_inorder(trans, path, idx) {
+		int cmp = cmp_int(path->btree_id, id) ?:
+			cmp_int(path->cached, key_cache);
+
+		if (cmp > 0)
+			break;
+		if (cmp < 0)
+			continue;
+
+		if (!(path->nodes_locked & 1) ||
+		    !path->should_be_locked)
+			continue;
+
+		if (!key_cache) {
+			if (bkey_cmp(pos, path->l[0].b->data->min_key) >= 0 &&
+			    bkey_cmp(pos, path->l[0].b->key.k.p) <= 0)
+				return;
+		} else {
+			if (!bkey_cmp(pos, path->pos))
+				return;
+		}
+	}
+
+	bch2_dump_trans_paths_updates(trans);
+	panic("not locked: %s %s%s\n",
+	      bch2_btree_ids[id],
+	      (bch2_bpos_to_text(&PBUF(buf), pos), buf),
+	      key_cache ? " cached" : "");
 }
 
 #else
@@ -1713,11 +1750,13 @@ void bch2_dump_trans_paths_updates(struct btree_trans *trans)
 	btree_trans_verify_sorted(trans);
 
 	trans_for_each_path_inorder(trans, path, idx)
-		printk(KERN_ERR "path: idx %u ref %u:%u%s btree %s pos %s %pS\n",
+		printk(KERN_ERR "path: idx %u ref %u:%u%s%s btree %s pos %s locks %u %pS\n",
 		       path->idx, path->ref, path->intent_ref,
-		       path->preserve ? " preserve" : "",
+		       path->should_be_locked ? " S" : "",
+		       path->preserve ? " P" : "",
 		       bch2_btree_ids[path->btree_id],
 		       (bch2_bpos_to_text(&PBUF(buf1), path->pos), buf1),
+		       path->nodes_locked,
 #ifdef CONFIG_BCACHEFS_DEBUG
 		       (void *) path->ip_allocated
 #else

--- a/fs/bcachefs/btree_iter.c
+++ b/fs/bcachefs/btree_iter.c
@@ -1647,19 +1647,19 @@ static struct btree_path *have_path_at_pos(struct btree_trans *trans, struct btr
 	return NULL;
 }
 
-static bool have_node_at_pos(struct btree_trans *trans, struct btree_path *path)
+static struct btree_path *have_node_at_pos(struct btree_trans *trans, struct btree_path *path)
 {
 	struct btree_path *next;
 
 	next = prev_btree_path(trans, path);
-	if (next && path_l(next)->b == path_l(path)->b)
-		return true;
+	if (next && next->level == path->level && path_l(next)->b == path_l(path)->b)
+		return next;
 
 	next = next_btree_path(trans, path);
-	if (next && path_l(next)->b == path_l(path)->b)
-		return true;
+	if (next && next->level == path->level && path_l(next)->b == path_l(path)->b)
+		return next;
 
-	return false;
+	return NULL;
 }
 
 static inline void __bch2_path_free(struct btree_trans *trans, struct btree_path *path)
@@ -1686,11 +1686,20 @@ void bch2_path_put(struct btree_trans *trans, struct btree_path *path, bool inte
 	    (dup = have_path_at_pos(trans, path))) {
 		dup->preserve = true;
 		path->preserve = false;
+		goto free;
 	}
 
 	if (!path->preserve &&
-	    have_node_at_pos(trans, path))
-		__bch2_path_free(trans, path);
+	    (dup = have_node_at_pos(trans, path)))
+		goto free;
+	return;
+free:
+	if (path->should_be_locked &&
+	    !btree_node_locked(dup, path->level))
+		return;
+
+	dup->should_be_locked |= path->should_be_locked;
+	__bch2_path_free(trans, path);
 }
 
 noinline __cold

--- a/fs/bcachefs/btree_iter.h
+++ b/fs/bcachefs/btree_iter.h
@@ -140,9 +140,13 @@ inline struct bkey_s_c bch2_btree_path_peek_slot(struct btree_path *, struct bke
 #ifdef CONFIG_BCACHEFS_DEBUG
 void bch2_trans_verify_paths(struct btree_trans *);
 void bch2_trans_verify_locks(struct btree_trans *);
+void bch2_assert_pos_locked(struct btree_trans *, enum btree_id,
+			    struct bpos, bool);
 #else
 static inline void bch2_trans_verify_paths(struct btree_trans *trans) {}
 static inline void bch2_trans_verify_locks(struct btree_trans *trans) {}
+static inline void bch2_assert_pos_locked(struct btree_trans *trans, enum btree_id id,
+					  struct bpos pos, bool key_cache) {}
 #endif
 
 void bch2_btree_path_fix_key_modified(struct btree_trans *trans,

--- a/fs/bcachefs/btree_iter.h
+++ b/fs/bcachefs/btree_iter.h
@@ -227,8 +227,6 @@ static inline void bch2_btree_iter_set_pos(struct btree_iter *iter, struct bpos 
 	iter->k.p.offset	= iter->pos.offset	= new_pos.offset;
 	iter->k.p.snapshot	= iter->pos.snapshot	= new_pos.snapshot;
 	iter->k.size = 0;
-	if (iter->path->ref == 1)
-		iter->path->should_be_locked = false;
 }
 
 static inline void bch2_btree_iter_set_pos_to_extent_start(struct btree_iter *iter)

--- a/fs/bcachefs/buckets.c
+++ b/fs/bcachefs/buckets.c
@@ -1203,10 +1203,14 @@ static int bch2_mark_reflink_p(struct btree_trans *trans,
 	struct bkey_s_c_reflink_p p = bkey_s_c_to_reflink_p(k);
 	struct reflink_gc *ref;
 	size_t l, r, m;
-	u64 idx = le64_to_cpu(p.v->idx) - le32_to_cpu(p.v->front_pad);
-	u64 end_idx = le64_to_cpu(p.v->idx) + p.k->size +
-		le32_to_cpu(p.v->back_pad);
+	u64 idx = le64_to_cpu(p.v->idx);
+	u64 end = le64_to_cpu(p.v->idx) + p.k->size;
 	int ret = 0;
+
+	if (c->sb.version >= bcachefs_metadata_version_reflink_p_fix) {
+		idx -= le32_to_cpu(p.v->front_pad);
+		end += le32_to_cpu(p.v->back_pad);
+	}
 
 	l = 0;
 	r = c->reflink_gc_nr;
@@ -1220,7 +1224,7 @@ static int bch2_mark_reflink_p(struct btree_trans *trans,
 			r = m;
 	}
 
-	while (idx < end_idx && !ret)
+	while (idx < end && !ret)
 		ret = __bch2_mark_reflink_p(c, p, &idx, flags, l++);
 
 	return ret;

--- a/fs/bcachefs/fs-io.c
+++ b/fs/bcachefs/fs-io.c
@@ -1126,7 +1126,6 @@ static void bch2_writepage_io_alloc(struct bch_fs *c,
 	op			= &w->io->op;
 	bch2_write_op_init(op, c, w->opts);
 	op->target		= w->opts.foreground_target;
-	op_journal_seq_set(op, &inode->ei_journal_seq);
 	op->nr_replicas		= nr_replicas;
 	op->res.nr_replicas	= nr_replicas;
 	op->write_point		= writepoint_hashed(inode->ei_last_dirtied);
@@ -1936,7 +1935,6 @@ static long bch2_dio_write_loop(struct dio_write *dio)
 		bch2_write_op_init(&dio->op, c, io_opts(c, &inode->ei_inode));
 		dio->op.end_io		= bch2_dio_write_loop_async;
 		dio->op.target		= dio->op.opts.foreground_target;
-		op_journal_seq_set(&dio->op, &inode->ei_journal_seq);
 		dio->op.write_point	= writepoint_hashed((unsigned long) current);
 		dio->op.nr_replicas	= dio->op.opts.data_replicas;
 		dio->op.subvol		= inode->ei_subvol;
@@ -2168,27 +2166,33 @@ unlock:
 
 /* fsync: */
 
+/*
+ * inode->ei_inode.bi_journal_seq won't be up to date since it's set in an
+ * insert trigger: look up the btree inode instead
+ */
+static int bch2_flush_inode(struct bch_fs *c, subvol_inum inum)
+{
+	struct bch_inode_unpacked inode;
+	int ret;
+
+	if (c->opts.journal_flush_disabled)
+		return 0;
+
+	ret = bch2_inode_find_by_inum(c, inum, &inode);
+	if (ret)
+		return ret;
+
+	return bch2_journal_flush_seq(&c->journal, inode.bi_journal_seq);
+}
+
 int bch2_fsync(struct file *file, loff_t start, loff_t end, int datasync)
 {
 	struct bch_inode_info *inode = file_bch_inode(file);
 	struct bch_fs *c = inode->v.i_sb->s_fs_info;
-	int ret, ret2;
+	int ret, ret2 = 0;
 
 	ret = file_write_and_wait_range(file, start, end);
-	if (ret)
-		return ret;
-
-	if (datasync && !(inode->v.i_state & I_DIRTY_DATASYNC))
-		goto out;
-
-	ret = sync_inode_metadata(&inode->v, 1);
-	if (ret)
-		return ret;
-out:
-	if (!c->opts.journal_flush_disabled)
-		ret = bch2_journal_flush_seq(&c->journal,
-					     inode->ei_journal_seq);
-	ret2 = file_check_and_advance_wb_err(file);
+	ret2 = bch2_flush_inode(c, inode_inum(inode));
 
 	return ret ?: ret2;
 }
@@ -2452,7 +2456,7 @@ int bch2_truncate(struct user_namespace *mnt_userns,
 
 	ret = bch2_fpunch(c, inode_inum(inode),
 			round_up(iattr->ia_size, block_bytes(c)) >> 9,
-			U64_MAX, &inode->ei_journal_seq, &i_sectors_delta);
+			U64_MAX, &i_sectors_delta);
 	i_sectors_acct(c, inode, NULL, i_sectors_delta);
 
 	if (unlikely(ret))
@@ -2512,7 +2516,6 @@ static long bchfs_fpunch(struct bch_inode_info *inode, loff_t offset, loff_t len
 
 		ret = bch2_fpunch(c, inode_inum(inode),
 				  discard_start, discard_end,
-				  &inode->ei_journal_seq,
 				  &i_sectors_delta);
 		i_sectors_acct(c, inode, NULL, i_sectors_delta);
 	}
@@ -2591,7 +2594,6 @@ static long bchfs_fcollapse_finsert(struct bch_inode_info *inode,
 
 		ret = bch2_fpunch(c, inode_inum(inode),
 				  offset >> 9, (offset + len) >> 9,
-				  &inode->ei_journal_seq,
 				  &i_sectors_delta);
 		i_sectors_acct(c, inode, NULL, i_sectors_delta);
 
@@ -2695,8 +2697,7 @@ reassemble:
 		ret =   bch2_btree_iter_traverse(&del) ?:
 			bch2_trans_update(&trans, &del, &delete, trigger_flags) ?:
 			bch2_trans_update(&trans, &dst, copy.k, trigger_flags) ?:
-			bch2_trans_commit(&trans, &disk_res,
-					  &inode->ei_journal_seq,
+			bch2_trans_commit(&trans, &disk_res, NULL,
 					  BTREE_INSERT_NOFAIL);
 		bch2_disk_reservation_put(c, &disk_res);
 
@@ -2807,7 +2808,7 @@ static int __bchfs_fallocate(struct bch_inode_info *inode, int mode,
 
 		ret = bch2_extent_update(&trans, inode_inum(inode), &iter,
 					 &reservation.k_i,
-				&disk_res, &inode->ei_journal_seq,
+				&disk_res, NULL,
 				0, &i_sectors_delta, true);
 		i_sectors_acct(c, inode, &quota_res, i_sectors_delta);
 bkey_err:
@@ -3011,7 +3012,6 @@ loff_t bch2_remap_file_range(struct file *file_src, loff_t pos_src,
 			       inode_inum(dst), pos_dst >> 9,
 			       inode_inum(src), pos_src >> 9,
 			       aligned_len >> 9,
-			       &dst->ei_journal_seq,
 			       pos_dst + len, &i_sectors_delta);
 	if (ret < 0)
 		goto err;
@@ -3029,10 +3029,9 @@ loff_t bch2_remap_file_range(struct file *file_src, loff_t pos_src,
 		i_size_write(&dst->v, pos_dst + ret);
 	spin_unlock(&dst->v.i_lock);
 
-	if (((file_dst->f_flags & (__O_SYNC | O_DSYNC)) ||
-	     IS_SYNC(file_inode(file_dst))) &&
-	    !c->opts.journal_flush_disabled)
-		ret = bch2_journal_flush_seq(&c->journal, dst->ei_journal_seq);
+	if ((file_dst->f_flags & (__O_SYNC | O_DSYNC)) ||
+	    IS_SYNC(file_inode(file_dst)))
+		ret = bch2_flush_inode(c, inode_inum(dst));
 err:
 	bch2_unlock_inodes(INODE_LOCK|INODE_PAGECACHE_BLOCK, src, dst);
 

--- a/fs/bcachefs/fs-io.c
+++ b/fs/bcachefs/fs-io.c
@@ -1172,16 +1172,16 @@ static int __bch2_writepage(struct page *page,
 do_io:
 	s = bch2_page_state_create(page, __GFP_NOFAIL);
 
-	ret = bch2_get_page_disk_reservation(c, inode, page, true);
-	if (ret) {
-		SetPageError(page);
-		mapping_set_error(page->mapping, ret);
-		unlock_page(page);
-		return 0;
-	}
+	/*
+	 * Things get really hairy with errors during writeback:
+	 */
+	ret = bch2_get_page_disk_reservation(c, inode, page, false);
+	BUG_ON(ret);
 
 	/* Before unlocking the page, get copy of reservations: */
+	spin_lock(&s->lock);
 	orig = *s;
+	spin_unlock(&s->lock);
 
 	for (i = 0; i < PAGE_SECTORS; i++) {
 		if (s->s[i].state < SECTOR_DIRTY)
@@ -1214,7 +1214,7 @@ do_io:
 
 	offset = 0;
 	while (1) {
-		unsigned sectors = 1, dirty_sectors = 0, reserved_sectors = 0;
+		unsigned sectors = 0, dirty_sectors = 0, reserved_sectors = 0;
 		u64 sector;
 
 		while (offset < PAGE_SECTORS &&
@@ -1224,16 +1224,15 @@ do_io:
 		if (offset == PAGE_SECTORS)
 			break;
 
-		sector = ((u64) page->index << PAGE_SECTOR_SHIFT) + offset;
-
 		while (offset + sectors < PAGE_SECTORS &&
-		       orig.s[offset + sectors].state >= SECTOR_DIRTY)
+		       orig.s[offset + sectors].state >= SECTOR_DIRTY) {
+			reserved_sectors += orig.s[offset + sectors].replicas_reserved;
+			dirty_sectors += orig.s[offset + sectors].state == SECTOR_DIRTY;
 			sectors++;
-
-		for (i = offset; i < offset + sectors; i++) {
-			reserved_sectors += orig.s[i].replicas_reserved;
-			dirty_sectors += orig.s[i].state == SECTOR_DIRTY;
 		}
+		BUG_ON(!sectors);
+
+		sector = ((u64) page->index << PAGE_SECTOR_SHIFT) + offset;
 
 		if (w->io &&
 		    (w->io->op.res.nr_replicas != nr_replicas_this_write ||

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -40,25 +40,6 @@ static void bch2_vfs_inode_init(struct bch_fs *, subvol_inum,
 				struct bch_inode_info *,
 				struct bch_inode_unpacked *);
 
-static void journal_seq_copy(struct bch_fs *c,
-			     struct bch_inode_info *dst,
-			     u64 journal_seq)
-{
-	/*
-	 * atomic64_cmpxchg has a fallback for archs that don't support it,
-	 * cmpxchg does not:
-	 */
-	atomic64_t *dst_seq = (void *) &dst->ei_journal_seq;
-	u64 old, v = READ_ONCE(dst->ei_journal_seq);
-
-	do {
-		old = v;
-
-		if (old >= journal_seq)
-			break;
-	} while ((v = atomic64_cmpxchg(dst_seq, old, journal_seq)) != old);
-}
-
 static void __pagecache_lock_put(struct pagecache_lock *lock, long i)
 {
 	BUG_ON(atomic_long_read(&lock->v) == 0);
@@ -151,9 +132,7 @@ retry:
 				BTREE_ITER_INTENT) ?:
 		(set ? set(inode, &inode_u, p) : 0) ?:
 		bch2_inode_write(&trans, &iter, &inode_u) ?:
-		bch2_trans_commit(&trans, NULL,
-				  &inode->ei_journal_seq,
-				  BTREE_INSERT_NOFAIL);
+		bch2_trans_commit(&trans, NULL, NULL, BTREE_INSERT_NOFAIL);
 
 	/*
 	 * the btree node lock protects inode->ei_inode, not ei_update_lock;
@@ -328,7 +307,6 @@ err_before_quota:
 	if (!(flags & BCH_CREATE_TMPFILE)) {
 		bch2_inode_update_after_write(c, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
-		journal_seq_copy(c, dir, journal_seq);
 		mutex_unlock(&dir->ei_update_lock);
 	}
 
@@ -336,7 +314,6 @@ err_before_quota:
 	inum.inum = inode_u.bi_inum;
 
 	bch2_vfs_inode_init(c, inum, inode, &inode_u);
-	journal_seq_copy(c, inode, journal_seq);
 
 	set_cached_acl(&inode->v, ACL_TYPE_ACCESS, acl);
 	set_cached_acl(&inode->v, ACL_TYPE_DEFAULT, default_acl);
@@ -361,7 +338,6 @@ err_before_quota:
 		 * We raced, another process pulled the new inode into cache
 		 * before us:
 		 */
-		journal_seq_copy(c, old, journal_seq);
 		make_bad_inode(&inode->v);
 		iput(&inode->v);
 
@@ -445,7 +421,7 @@ static int __bch2_link(struct bch_fs *c,
 	mutex_lock(&inode->ei_update_lock);
 	bch2_trans_init(&trans, c, 4, 1024);
 
-	ret = __bch2_trans_do(&trans, NULL, &inode->ei_journal_seq, 0,
+	ret = __bch2_trans_do(&trans, NULL, NULL, 0,
 			bch2_link_trans(&trans,
 					inode_inum(dir),   &dir_u,
 					inode_inum(inode), &inode_u,
@@ -454,7 +430,6 @@ static int __bch2_link(struct bch_fs *c,
 	if (likely(!ret)) {
 		BUG_ON(inode_u.bi_inum != inode->v.i_ino);
 
-		journal_seq_copy(c, inode, dir->ei_journal_seq);
 		bch2_inode_update_after_write(c, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
 		bch2_inode_update_after_write(c, inode, &inode_u, ATTR_CTIME);
@@ -497,7 +472,7 @@ int __bch2_unlink(struct inode *vdir, struct dentry *dentry,
 	bch2_lock_inodes(INODE_UPDATE_LOCK, dir, inode);
 	bch2_trans_init(&trans, c, 4, 1024);
 
-	ret = __bch2_trans_do(&trans, NULL, &dir->ei_journal_seq,
+	ret = __bch2_trans_do(&trans, NULL, NULL,
 			      BTREE_INSERT_NOFAIL,
 			bch2_unlink_trans(&trans,
 					  inode_inum(dir), &dir_u,
@@ -507,7 +482,6 @@ int __bch2_unlink(struct inode *vdir, struct dentry *dentry,
 	if (likely(!ret)) {
 		BUG_ON(inode_u.bi_inum != inode->v.i_ino);
 
-		journal_seq_copy(c, inode, dir->ei_journal_seq);
 		bch2_inode_update_after_write(c, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
 		bch2_inode_update_after_write(c, inode, &inode_u,
@@ -549,8 +523,6 @@ static int bch2_symlink(struct user_namespace *mnt_userns,
 	if (unlikely(ret))
 		goto err;
 
-	journal_seq_copy(c, dir, inode->ei_journal_seq);
-
 	ret = __bch2_link(c, inode, dir, dentry);
 	if (unlikely(ret))
 		goto err;
@@ -585,7 +557,6 @@ static int bch2_rename2(struct user_namespace *mnt_userns,
 		? BCH_RENAME_EXCHANGE
 		: dst_dentry->d_inode
 		? BCH_RENAME_OVERWRITE : BCH_RENAME;
-	u64 journal_seq = 0;
 	int ret;
 
 	if (flags & ~(RENAME_NOREPLACE|RENAME_EXCHANGE))
@@ -625,7 +596,7 @@ static int bch2_rename2(struct user_namespace *mnt_userns,
 			goto err;
 	}
 
-	ret = __bch2_trans_do(&trans, NULL, &journal_seq, 0,
+	ret = __bch2_trans_do(&trans, NULL, NULL, 0,
 			bch2_rename_trans(&trans,
 					  inode_inum(src_dir), &src_dir_u,
 					  inode_inum(dst_dir), &dst_dir_u,
@@ -643,23 +614,17 @@ static int bch2_rename2(struct user_namespace *mnt_userns,
 
 	bch2_inode_update_after_write(c, src_dir, &src_dir_u,
 				      ATTR_MTIME|ATTR_CTIME);
-	journal_seq_copy(c, src_dir, journal_seq);
 
-	if (src_dir != dst_dir) {
+	if (src_dir != dst_dir)
 		bch2_inode_update_after_write(c, dst_dir, &dst_dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
-		journal_seq_copy(c, dst_dir, journal_seq);
-	}
 
 	bch2_inode_update_after_write(c, src_inode, &src_inode_u,
 				      ATTR_CTIME);
-	journal_seq_copy(c, src_inode, journal_seq);
 
-	if (dst_inode) {
+	if (dst_inode)
 		bch2_inode_update_after_write(c, dst_inode, &dst_inode_u,
 					      ATTR_CTIME);
-		journal_seq_copy(c, dst_inode, journal_seq);
-	}
 err:
 	bch2_trans_exit(&trans);
 
@@ -766,8 +731,7 @@ retry:
 	}
 
 	ret =   bch2_inode_write(&trans, &inode_iter, &inode_u) ?:
-		bch2_trans_commit(&trans, NULL,
-				  &inode->ei_journal_seq,
+		bch2_trans_commit(&trans, NULL, NULL,
 				  BTREE_INSERT_NOFAIL);
 btree_err:
 	bch2_trans_iter_exit(&trans, &inode_iter);
@@ -1201,7 +1165,6 @@ static void bch2_vfs_inode_init(struct bch_fs *c, subvol_inum inum,
 	inode->v.i_size		= bi->bi_size;
 
 	inode->ei_flags		= 0;
-	inode->ei_journal_seq	= bi->bi_journal_seq;
 	inode->ei_quota_reserved = 0;
 	inode->ei_qid		= bch_qid(bi);
 	inode->ei_subvol	= inum.subvol;
@@ -1240,7 +1203,6 @@ static struct inode *bch2_alloc_inode(struct super_block *sb)
 	mutex_init(&inode->ei_update_lock);
 	pagecache_lock_init(&inode->ei_pagecache_lock);
 	mutex_init(&inode->ei_quota_lock);
-	inode->ei_journal_seq = 0;
 
 	return &inode->v;
 }

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -36,7 +36,7 @@
 
 static struct kmem_cache *bch2_inode_cache;
 
-static void bch2_vfs_inode_init(struct bch_fs *, subvol_inum,
+static void bch2_vfs_inode_init(struct btree_trans *, subvol_inum,
 				struct bch_inode_info *,
 				struct bch_inode_unpacked *);
 
@@ -92,11 +92,19 @@ void bch2_pagecache_block_get(struct pagecache_lock *lock)
 	__pagecache_lock_get(lock, -1);
 }
 
-void bch2_inode_update_after_write(struct bch_fs *c,
+void bch2_inode_update_after_write(struct btree_trans *trans,
 				   struct bch_inode_info *inode,
 				   struct bch_inode_unpacked *bi,
 				   unsigned fields)
 {
+	struct bch_fs *c = trans->c;
+
+	BUG_ON(bi->bi_inum != inode->v.i_ino);
+
+	bch2_assert_pos_locked(trans, BTREE_ID_inodes,
+			       POS(0, bi->bi_inum),
+			       0 && c->opts.inodes_use_key_cache);
+
 	set_nlink(&inode->v, bch2_inode_nlink_get(bi));
 	i_uid_write(&inode->v, bi->bi_uid);
 	i_gid_write(&inode->v, bi->bi_gid);
@@ -125,6 +133,7 @@ int __must_check bch2_write_inode(struct bch_fs *c,
 	int ret;
 
 	bch2_trans_init(&trans, c, 0, 512);
+	trans.ip = _RET_IP_;
 retry:
 	bch2_trans_begin(&trans);
 
@@ -139,7 +148,7 @@ retry:
 	 * this is important for inode updates via bchfs_write_index_update
 	 */
 	if (!ret)
-		bch2_inode_update_after_write(c, inode, &inode_u, fields);
+		bch2_inode_update_after_write(&trans, inode, &inode_u, fields);
 
 	bch2_trans_iter_exit(&trans, &iter);
 
@@ -214,6 +223,7 @@ struct inode *bch2_vfs_inode_get(struct bch_fs *c, subvol_inum inum)
 {
 	struct bch_inode_unpacked inode_u;
 	struct bch_inode_info *inode;
+	struct btree_trans trans;
 	int ret;
 
 	inode = to_bch_ei(iget5_locked(c->vfs_sb,
@@ -226,13 +236,18 @@ struct inode *bch2_vfs_inode_get(struct bch_fs *c, subvol_inum inum)
 	if (!(inode->v.i_state & I_NEW))
 		return &inode->v;
 
-	ret = bch2_inode_find_by_inum(c, inum, &inode_u);
+	bch2_trans_init(&trans, c, 8, 0);
+	ret = lockrestart_do(&trans,
+		bch2_inode_find_by_inum_trans(&trans, inum, &inode_u));
+
+	if (!ret)
+		bch2_vfs_inode_init(&trans, inum, inode, &inode_u);
+	bch2_trans_exit(&trans);
+
 	if (ret) {
 		iget_failed(&inode->v);
 		return ERR_PTR(ret);
 	}
-
-	bch2_vfs_inode_init(c, inum, inode, &inode_u);
 
 	unlock_new_inode(&inode->v);
 
@@ -305,7 +320,7 @@ err_before_quota:
 	}
 
 	if (!(flags & BCH_CREATE_TMPFILE)) {
-		bch2_inode_update_after_write(c, dir, &dir_u,
+		bch2_inode_update_after_write(&trans, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
 		mutex_unlock(&dir->ei_update_lock);
 	}
@@ -313,7 +328,8 @@ err_before_quota:
 	inum.subvol = inode_u.bi_subvol ?: dir->ei_subvol;
 	inum.inum = inode_u.bi_inum;
 
-	bch2_vfs_inode_init(c, inum, inode, &inode_u);
+	bch2_iget5_set(&inode->v, &inum);
+	bch2_vfs_inode_init(&trans, inum, inode, &inode_u);
 
 	set_cached_acl(&inode->v, ACL_TYPE_ACCESS, acl);
 	set_cached_acl(&inode->v, ACL_TYPE_DEFAULT, default_acl);
@@ -428,11 +444,9 @@ static int __bch2_link(struct bch_fs *c,
 					&dentry->d_name));
 
 	if (likely(!ret)) {
-		BUG_ON(inode_u.bi_inum != inode->v.i_ino);
-
-		bch2_inode_update_after_write(c, dir, &dir_u,
+		bch2_inode_update_after_write(&trans, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
-		bch2_inode_update_after_write(c, inode, &inode_u, ATTR_CTIME);
+		bch2_inode_update_after_write(&trans, inode, &inode_u, ATTR_CTIME);
 	}
 
 	bch2_trans_exit(&trans);
@@ -480,11 +494,9 @@ int __bch2_unlink(struct inode *vdir, struct dentry *dentry,
 					  deleting_snapshot));
 
 	if (likely(!ret)) {
-		BUG_ON(inode_u.bi_inum != inode->v.i_ino);
-
-		bch2_inode_update_after_write(c, dir, &dir_u,
+		bch2_inode_update_after_write(&trans, dir, &dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
-		bch2_inode_update_after_write(c, inode, &inode_u,
+		bch2_inode_update_after_write(&trans, inode, &inode_u,
 					      ATTR_MTIME);
 	}
 
@@ -612,18 +624,18 @@ static int bch2_rename2(struct user_namespace *mnt_userns,
 	BUG_ON(dst_inode &&
 	       dst_inode->v.i_ino != dst_inode_u.bi_inum);
 
-	bch2_inode_update_after_write(c, src_dir, &src_dir_u,
+	bch2_inode_update_after_write(&trans, src_dir, &src_dir_u,
 				      ATTR_MTIME|ATTR_CTIME);
 
 	if (src_dir != dst_dir)
-		bch2_inode_update_after_write(c, dst_dir, &dst_dir_u,
+		bch2_inode_update_after_write(&trans, dst_dir, &dst_dir_u,
 					      ATTR_MTIME|ATTR_CTIME);
 
-	bch2_inode_update_after_write(c, src_inode, &src_inode_u,
+	bch2_inode_update_after_write(&trans, src_inode, &src_inode_u,
 				      ATTR_CTIME);
 
 	if (dst_inode)
-		bch2_inode_update_after_write(c, dst_inode, &dst_inode_u,
+		bch2_inode_update_after_write(&trans, dst_inode, &dst_inode_u,
 					      ATTR_CTIME);
 err:
 	bch2_trans_exit(&trans);
@@ -741,7 +753,7 @@ btree_err:
 	if (unlikely(ret))
 		goto err_trans;
 
-	bch2_inode_update_after_write(c, inode, &inode_u, attr->ia_valid);
+	bch2_inode_update_after_write(&trans, inode, &inode_u, attr->ia_valid);
 
 	if (acl)
 		set_cached_acl(&inode->v, ACL_TYPE_ACCESS, acl);
@@ -1152,11 +1164,11 @@ static const struct export_operations bch_export_ops = {
 	//.get_parent	= bch2_get_parent,
 };
 
-static void bch2_vfs_inode_init(struct bch_fs *c, subvol_inum inum,
+static void bch2_vfs_inode_init(struct btree_trans *trans, subvol_inum inum,
 				struct bch_inode_info *inode,
 				struct bch_inode_unpacked *bi)
 {
-	bch2_inode_update_after_write(c, inode, bi, ~0);
+	bch2_inode_update_after_write(trans, inode, bi, ~0);
 
 	inode->v.i_blocks	= bi->bi_sectors;
 	inode->v.i_ino		= bi->bi_inum;

--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -1122,17 +1122,25 @@ static const struct address_space_operations bch_address_space_operations = {
 	.error_remove_page = generic_error_remove_page,
 };
 
-#if 0
+/**
+ * experimental NFS code,
+ * please note that this code only accepts the primary subvolume,
+ * so snapshots won't be supported
+ * also, much functionality is not implemented
+ * so, for now, if NFS is required,
+ * keep it as basic as possible
+ **/
 static struct inode *bch2_nfs_get_inode(struct super_block *sb,
 		u64 ino, u32 generation)
 {
 	struct bch_fs *c = sb->s_fs_info;
 	struct inode *vinode;
+	subvol_inum subi = { .subvol = 1,  ino };
 
 	if (ino < BCACHEFS_ROOT_INO)
 		return ERR_PTR(-ESTALE);
 
-	vinode = bch2_vfs_inode_get(c, ino);
+	vinode = bch2_vfs_inode_get(c, subi);
 	if (IS_ERR(vinode))
 		return ERR_CAST(vinode);
 	if (generation && vinode->i_generation != generation) {
@@ -1156,13 +1164,15 @@ static struct dentry *bch2_fh_to_parent(struct super_block *sb, struct fid *fid,
 	return generic_fh_to_parent(sb, fid, fh_len, fh_type,
 				    bch2_nfs_get_inode);
 }
-#endif
 
 static const struct export_operations bch_export_ops = {
-	//.fh_to_dentry	= bch2_fh_to_dentry,
-	//.fh_to_parent	= bch2_fh_to_parent,
-	//.get_parent	= bch2_get_parent,
+	.fh_to_dentry	= bch2_fh_to_dentry,
+	.fh_to_parent	= bch2_fh_to_parent,
 };
+
+/*
+ * -- end of experimental NFS code --
+ * */
 
 static void bch2_vfs_inode_init(struct btree_trans *trans, subvol_inum inum,
 				struct bch_inode_info *inode,

--- a/fs/bcachefs/fs.h
+++ b/fs/bcachefs/fs.h
@@ -36,7 +36,6 @@ struct bch_inode_info {
 	unsigned long		ei_flags;
 
 	struct mutex		ei_update_lock;
-	u64			ei_journal_seq;
 	u64			ei_quota_reserved;
 	unsigned long		ei_last_dirtied;
 

--- a/fs/bcachefs/fs.h
+++ b/fs/bcachefs/fs.h
@@ -173,7 +173,7 @@ struct inode *bch2_vfs_inode_get(struct bch_fs *, subvol_inum);
 typedef int (*inode_set_fn)(struct bch_inode_info *,
 			    struct bch_inode_unpacked *, void *);
 
-void bch2_inode_update_after_write(struct bch_fs *,
+void bch2_inode_update_after_write(struct btree_trans *,
 				   struct bch_inode_info *,
 				   struct bch_inode_unpacked *,
 				   unsigned);

--- a/fs/bcachefs/inode.c
+++ b/fs/bcachefs/inode.c
@@ -722,9 +722,9 @@ err:
 	return ret;
 }
 
-static int bch2_inode_find_by_inum_trans(struct btree_trans *trans,
-					 subvol_inum inum,
-					 struct bch_inode_unpacked *inode)
+int bch2_inode_find_by_inum_trans(struct btree_trans *trans,
+				  subvol_inum inum,
+				  struct bch_inode_unpacked *inode)
 {
 	struct btree_iter iter;
 	int ret;

--- a/fs/bcachefs/inode.h
+++ b/fs/bcachefs/inode.h
@@ -89,6 +89,8 @@ int bch2_inode_create(struct btree_trans *, struct btree_iter *,
 
 int bch2_inode_rm(struct bch_fs *, subvol_inum, bool);
 
+int bch2_inode_find_by_inum_trans(struct btree_trans *, subvol_inum,
+				  struct bch_inode_unpacked *);
 int bch2_inode_find_by_inum(struct bch_fs *, subvol_inum,
 			    struct bch_inode_unpacked *);
 

--- a/fs/bcachefs/io.c
+++ b/fs/bcachefs/io.c
@@ -376,7 +376,7 @@ int bch2_extent_update(struct btree_trans *trans,
  */
 int bch2_fpunch_at(struct btree_trans *trans, struct btree_iter *iter,
 		   subvol_inum inum, u64 end,
-		   u64 *journal_seq, s64 *i_sectors_delta)
+		   s64 *i_sectors_delta)
 {
 	struct bch_fs *c	= trans->c;
 	unsigned max_sectors	= KEY_SIZE_MAX & (~0 << c->block_bits);
@@ -414,7 +414,7 @@ int bch2_fpunch_at(struct btree_trans *trans, struct btree_iter *iter,
 		bch2_cut_back(end_pos, &delete);
 
 		ret = bch2_extent_update(trans, inum, iter, &delete,
-				&disk_res, journal_seq,
+				&disk_res, NULL,
 				0, i_sectors_delta, false);
 		bch2_disk_reservation_put(c, &disk_res);
 btree_err:
@@ -433,7 +433,7 @@ btree_err:
 }
 
 int bch2_fpunch(struct bch_fs *c, subvol_inum inum, u64 start, u64 end,
-		u64 *journal_seq, s64 *i_sectors_delta)
+		s64 *i_sectors_delta)
 {
 	struct btree_trans trans;
 	struct btree_iter iter;
@@ -444,8 +444,7 @@ int bch2_fpunch(struct bch_fs *c, subvol_inum inum, u64 start, u64 end,
 			     POS(inum.inum, start),
 			     BTREE_ITER_INTENT);
 
-	ret = bch2_fpunch_at(&trans, &iter, inum, end,
-			     journal_seq, i_sectors_delta);
+	ret = bch2_fpunch_at(&trans, &iter, inum, end, i_sectors_delta);
 
 	bch2_trans_iter_exit(&trans, &iter);
 	bch2_trans_exit(&trans);

--- a/fs/bcachefs/io.c
+++ b/fs/bcachefs/io.c
@@ -325,26 +325,31 @@ int bch2_fpunch_at(struct btree_trans *trans, struct btree_iter *iter,
 	int ret = 0, ret2 = 0;
 	u32 snapshot;
 
-	while (1) {
+	while (!ret || ret == -EINTR) {
 		struct disk_reservation disk_res =
 			bch2_disk_reservation_init(c, 0);
 		struct bkey_i delete;
+
+		if (ret)
+			ret2 = ret;
 
 		bch2_trans_begin(trans);
 
 		ret = bch2_subvolume_get_snapshot(trans, inum.subvol, &snapshot);
 		if (ret)
-			goto btree_err;
+			continue;
 
 		bch2_btree_iter_set_snapshot(iter, snapshot);
 
 		k = bch2_btree_iter_peek(iter);
-		if (bkey_cmp(iter->pos, end_pos) >= 0)
+		if (bkey_cmp(iter->pos, end_pos) >= 0) {
+			bch2_btree_iter_set_pos(iter, end_pos);
 			break;
+		}
 
 		ret = bkey_err(k);
 		if (ret)
-			goto btree_err;
+			continue;
 
 		bkey_init(&delete.k);
 		delete.k.p = iter->pos;
@@ -357,17 +362,7 @@ int bch2_fpunch_at(struct btree_trans *trans, struct btree_iter *iter,
 				&disk_res, NULL,
 				0, i_sectors_delta, false);
 		bch2_disk_reservation_put(c, &disk_res);
-btree_err:
-		if (ret == -EINTR) {
-			ret2 = ret;
-			ret = 0;
-		}
-		if (ret)
-			break;
 	}
-
-	if (bkey_cmp(iter->pos, end_pos) > 0)
-		bch2_btree_iter_set_pos(iter, end_pos);
 
 	return ret ?: ret2;
 }

--- a/fs/bcachefs/io.h
+++ b/fs/bcachefs/io.h
@@ -48,12 +48,6 @@ static inline u64 *op_journal_seq(struct bch_write_op *op)
 		? op->journal_seq_p : &op->journal_seq;
 }
 
-static inline void op_journal_seq_set(struct bch_write_op *op, u64 *journal_seq)
-{
-	op->journal_seq_p = journal_seq;
-	op->flags |= BCH_WRITE_JOURNAL_SEQ_PTR;
-}
-
 static inline struct workqueue_struct *index_update_wq(struct bch_write_op *op)
 {
 	return op->alloc_reserve == RESERVE_MOVINGGC
@@ -68,8 +62,8 @@ int bch2_extent_update(struct btree_trans *, subvol_inum,
 		       struct disk_reservation *, u64 *, u64, s64 *, bool);
 
 int bch2_fpunch_at(struct btree_trans *, struct btree_iter *,
-		   subvol_inum, u64, u64 *, s64 *);
-int bch2_fpunch(struct bch_fs *c, subvol_inum, u64, u64, u64 *, s64 *);
+		   subvol_inum, u64, s64 *);
+int bch2_fpunch(struct bch_fs *c, subvol_inum, u64, u64, s64 *);
 
 int bch2_write_index_default(struct bch_write_op *);
 

--- a/fs/bcachefs/io.h
+++ b/fs/bcachefs/io.h
@@ -56,7 +56,7 @@ static inline struct workqueue_struct *index_update_wq(struct bch_write_op *op)
 }
 
 int bch2_sum_sector_overwrites(struct btree_trans *, struct btree_iter *,
-			       struct bkey_i *, bool *, bool *, s64 *, s64 *);
+			       struct bkey_i *, bool *, s64 *, s64 *);
 int bch2_extent_update(struct btree_trans *, subvol_inum,
 		       struct btree_iter *, struct bkey_i *,
 		       struct disk_reservation *, u64 *, u64, s64 *, bool);

--- a/fs/bcachefs/move.c
+++ b/fs/bcachefs/move.c
@@ -160,7 +160,7 @@ static int bch2_migrate_index_update(struct bch_write_op *op)
 		struct extent_ptr_decoded p;
 		struct bpos next_pos;
 		bool did_work = false;
-		bool extending = false, should_check_enospc;
+		bool should_check_enospc;
 		s64 i_sectors_delta = 0, disk_sectors_delta = 0;
 
 		bch2_trans_begin(&trans);
@@ -226,7 +226,6 @@ static int bch2_migrate_index_update(struct bch_write_op *op)
 					       op->opts.data_replicas);
 
 		ret = bch2_sum_sector_overwrites(&trans, &iter, insert,
-						 &extending,
 						 &should_check_enospc,
 						 &i_sectors_delta,
 						 &disk_sectors_delta);

--- a/fs/bcachefs/reflink.c
+++ b/fs/bcachefs/reflink.c
@@ -210,7 +210,7 @@ static struct bkey_s_c get_next_src(struct btree_iter *iter, struct bpos end)
 s64 bch2_remap_range(struct bch_fs *c,
 		     subvol_inum dst_inum, u64 dst_offset,
 		     subvol_inum src_inum, u64 src_offset,
-		     u64 remap_sectors, u64 *journal_seq,
+		     u64 remap_sectors,
 		     u64 new_i_size, s64 *i_sectors_delta)
 {
 	struct btree_trans trans;
@@ -281,7 +281,7 @@ s64 bch2_remap_range(struct bch_fs *c,
 					min(dst_end.offset,
 					    dst_iter.pos.offset +
 					    src_iter.pos.offset - src_want.offset),
-					journal_seq, i_sectors_delta);
+					i_sectors_delta);
 			continue;
 		}
 
@@ -320,7 +320,7 @@ s64 bch2_remap_range(struct bch_fs *c,
 				    dst_end.offset - dst_iter.pos.offset));
 
 		ret = bch2_extent_update(&trans, dst_inum, &dst_iter,
-					 new_dst.k, &disk_res, journal_seq,
+					 new_dst.k, &disk_res, NULL,
 					 new_i_size, i_sectors_delta,
 					 true);
 		bch2_disk_reservation_put(c, &disk_res);
@@ -347,7 +347,7 @@ s64 bch2_remap_range(struct bch_fs *c,
 		    inode_u.bi_size < new_i_size) {
 			inode_u.bi_size = new_i_size;
 			ret2  = bch2_inode_write(&trans, &inode_iter, &inode_u) ?:
-				bch2_trans_commit(&trans, NULL, journal_seq, 0);
+				bch2_trans_commit(&trans, NULL, NULL, 0);
 		}
 
 		bch2_trans_iter_exit(&trans, &inode_iter);

--- a/fs/bcachefs/reflink.c
+++ b/fs/bcachefs/reflink.c
@@ -347,7 +347,8 @@ s64 bch2_remap_range(struct bch_fs *c,
 		    inode_u.bi_size < new_i_size) {
 			inode_u.bi_size = new_i_size;
 			ret2  = bch2_inode_write(&trans, &inode_iter, &inode_u) ?:
-				bch2_trans_commit(&trans, NULL, NULL, 0);
+				bch2_trans_commit(&trans, NULL, NULL,
+						  BTREE_INSERT_NOFAIL);
 		}
 
 		bch2_trans_iter_exit(&trans, &inode_iter);

--- a/fs/bcachefs/reflink.h
+++ b/fs/bcachefs/reflink.h
@@ -58,6 +58,6 @@ static inline __le64 *bkey_refcount(struct bkey_i *k)
 }
 
 s64 bch2_remap_range(struct bch_fs *, subvol_inum, u64,
-		     subvol_inum, u64, u64, u64 *, u64, s64 *);
+		     subvol_inum, u64, u64, u64, s64 *);
 
 #endif /* _BCACHEFS_REFLINK_H */

--- a/fs/bcachefs/super.c
+++ b/fs/bcachefs/super.c
@@ -588,48 +588,53 @@ void bch2_fs_stop(struct bch_fs *c)
 	bch2_fs_free(c);
 }
 
-static const char *bch2_fs_online(struct bch_fs *c)
+static int bch2_fs_online(struct bch_fs *c)
 {
 	struct bch_dev *ca;
-	const char *err = NULL;
 	unsigned i;
-	int ret;
+	int ret = 0;
 
 	lockdep_assert_held(&bch_fs_list_lock);
 
-	if (!list_empty(&c->list))
-		return NULL;
-
-	if (__bch2_uuid_to_fs(c->sb.uuid))
-		return "filesystem UUID already open";
+	if (__bch2_uuid_to_fs(c->sb.uuid)) {
+		bch_err(c, "filesystem UUID already open");
+		return -EINVAL;
+	}
 
 	ret = bch2_fs_chardev_init(c);
-	if (ret)
-		return "error creating character device";
+	if (ret) {
+		bch_err(c, "error creating character device");
+		return ret;
+	}
 
 	bch2_fs_debug_init(c);
 
-	if (kobject_add(&c->kobj, NULL, "%pU", c->sb.user_uuid.b) ||
-	    kobject_add(&c->internal, &c->kobj, "internal") ||
-	    kobject_add(&c->opts_dir, &c->kobj, "options") ||
-	    kobject_add(&c->time_stats, &c->kobj, "time_stats") ||
-	    bch2_opts_create_sysfs_files(&c->opts_dir))
-		return "error creating sysfs objects";
+	ret = kobject_add(&c->kobj, NULL, "%pU", c->sb.user_uuid.b) ?:
+	    kobject_add(&c->internal, &c->kobj, "internal") ?:
+	    kobject_add(&c->opts_dir, &c->kobj, "options") ?:
+	    kobject_add(&c->time_stats, &c->kobj, "time_stats") ?:
+	    bch2_opts_create_sysfs_files(&c->opts_dir);
+	if (ret) {
+		bch_err(c, "error creating sysfs objects");
+		return ret;
+	}
 
 	down_write(&c->state_lock);
 
-	err = "error creating sysfs objects";
-	for_each_member_device(ca, c, i)
-		if (bch2_dev_sysfs_online(c, ca)) {
+	for_each_member_device(ca, c, i) {
+		ret = bch2_dev_sysfs_online(c, ca);
+		if (ret) {
+			bch_err(c, "error creating sysfs objects");
 			percpu_ref_put(&ca->ref);
 			goto err;
 		}
+	}
 
+	BUG_ON(!list_empty(&c->list));
 	list_add(&c->list, &bch_fs_list);
-	err = NULL;
 err:
 	up_write(&c->state_lock);
-	return err;
+	return ret;
 }
 
 static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
@@ -637,7 +642,6 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	struct bch_sb_field_members *mi;
 	struct bch_fs *c;
 	unsigned i, iter_size;
-	const char *err;
 	int ret = 0;
 
 	pr_verbose_init(opts, "");
@@ -727,20 +731,16 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 
 	mutex_init(&c->sectors_available_lock);
 
-	if (percpu_init_rwsem(&c->mark_lock)) {
-		ret = -ENOMEM;
+	ret = percpu_init_rwsem(&c->mark_lock);
+	if (ret)
 		goto err;
-	}
 
 	mutex_lock(&c->sb_lock);
-
-	if (bch2_sb_to_fs(c, sb)) {
-		mutex_unlock(&c->sb_lock);
-		ret = -ENOMEM;
-		goto err;
-	}
-
+	ret = bch2_sb_to_fs(c, sb);
 	mutex_unlock(&c->sb_lock);
+
+	if (ret)
+		goto err;
 
 	scnprintf(c->name, sizeof(c->name), "%pU", &c->sb.user_uuid);
 
@@ -752,7 +752,8 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	c->btree_foreground_merge_threshold = BTREE_FOREGROUND_MERGE_THRESHOLD(c);
 
 	if (bch2_fs_init_fault("fs_alloc")) {
-		ret = -ENOMEM;
+		bch_err(c, "fs_alloc fault injected");
+		ret = -EFAULT;
 		goto err;
 	}
 
@@ -784,25 +785,25 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 					btree_bytes(c)) ||
 	    mempool_init_kmalloc_pool(&c->large_bkey_pool, 1, 2048) ||
 	    !(c->unused_inode_hints = kcalloc(1U << c->inode_shard_bits,
-					      sizeof(u64), GFP_KERNEL)) ||
-	    bch2_io_clock_init(&c->io_clock[READ]) ||
-	    bch2_io_clock_init(&c->io_clock[WRITE]) ||
-	    bch2_fs_journal_init(&c->journal) ||
-	    bch2_fs_replicas_init(c) ||
-	    bch2_fs_btree_cache_init(c) ||
-	    bch2_fs_btree_key_cache_init(&c->btree_key_cache) ||
-	    bch2_fs_btree_iter_init(c) ||
-	    bch2_fs_btree_interior_update_init(c) ||
-	    bch2_fs_subvolumes_init(c) ||
-	    bch2_fs_io_init(c) ||
-	    bch2_fs_compress_init(c) ||
-	    bch2_fs_ec_init(c) ||
-	    bch2_fs_fsio_init(c)) {
+					      sizeof(u64), GFP_KERNEL))) {
 		ret = -ENOMEM;
 		goto err;
 	}
 
-	ret = bch2_fs_encryption_init(c);
+	ret = bch2_io_clock_init(&c->io_clock[READ]) ?:
+	    bch2_io_clock_init(&c->io_clock[WRITE]) ?:
+	    bch2_fs_journal_init(&c->journal) ?:
+	    bch2_fs_replicas_init(c) ?:
+	    bch2_fs_btree_cache_init(c) ?:
+	    bch2_fs_btree_key_cache_init(&c->btree_key_cache) ?:
+	    bch2_fs_btree_iter_init(c) ?:
+	    bch2_fs_btree_interior_update_init(c) ?:
+	    bch2_fs_subvolumes_init(c) ?:
+	    bch2_fs_io_init(c) ?:
+	    bch2_fs_encryption_init(c) ?:
+	    bch2_fs_compress_init(c) ?:
+	    bch2_fs_ec_init(c) ?:
+	    bch2_fs_fsio_init(c);
 	if (ret)
 		goto err;
 
@@ -813,7 +814,7 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	for (i = 0; i < c->sb.nr_devices; i++)
 		if (bch2_dev_exists(c->disk_sb.sb, mi, i) &&
 		    bch2_dev_alloc(c, i)) {
-			ret = -ENOMEM;
+			ret = -EEXIST;
 			goto err;
 		}
 
@@ -826,13 +827,11 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 			(sizeof(struct jset_entry_clock) / sizeof(u64)) * 2);
 
 	mutex_lock(&bch_fs_list_lock);
-	err = bch2_fs_online(c);
+	ret = bch2_fs_online(c);
 	mutex_unlock(&bch_fs_list_lock);
-	if (err) {
-		bch_err(c, "bch2_fs_online() error: %s", err);
-		ret = -ENOMEM;
+
+	if (ret)
 		goto err;
-	}
 out:
 	pr_verbose_init(opts, "ret %i", PTR_ERR_OR_ZERO(c));
 	return c;
@@ -878,7 +877,6 @@ static void print_mount_opts(struct bch_fs *c)
 
 int bch2_fs_start(struct bch_fs *c)
 {
-	const char *err = "cannot allocate memory";
 	struct bch_sb_field_members *mi;
 	struct bch_dev *ca;
 	time64_t now = ktime_get_real_seconds();
@@ -914,10 +912,11 @@ int bch2_fs_start(struct bch_fs *c)
 	if (ret)
 		goto err;
 
-	err = "dynamic fault";
 	ret = -EINVAL;
-	if (bch2_fs_init_fault("fs_start"))
+	if (bch2_fs_init_fault("fs_start")) {
+		bch_err(c, "fs_start fault injected");
 		goto err;
+	}
 
 	set_bit(BCH_FS_STARTED, &c->flags);
 
@@ -938,7 +937,6 @@ int bch2_fs_start(struct bch_fs *c)
 	if (c->opts.read_only || c->opts.nochanges) {
 		bch2_fs_read_only(c);
 	} else {
-		err = "error going read write";
 		ret = !test_bit(BCH_FS_RW, &c->flags)
 			? bch2_fs_read_write(c)
 			: bch2_fs_read_write_late(c);
@@ -956,25 +954,22 @@ err:
 	case BCH_FSCK_ERRORS_NOT_FIXED:
 		bch_err(c, "filesystem contains errors: please report this to the developers");
 		pr_cont("mount with -o fix_errors to repair\n");
-		err = "fsck error";
 		break;
 	case BCH_FSCK_REPAIR_UNIMPLEMENTED:
 		bch_err(c, "filesystem contains errors: please report this to the developers");
 		pr_cont("repair unimplemented: inform the developers so that it can be added\n");
-		err = "fsck error";
 		break;
 	case BCH_FSCK_REPAIR_IMPOSSIBLE:
 		bch_err(c, "filesystem contains errors, but repair impossible");
-		err = "fsck error";
 		break;
 	case BCH_FSCK_UNKNOWN_VERSION:
-		err = "unknown metadata version";;
+		bch_err(c, "unknown metadata version");
 		break;
 	case -ENOMEM:
-		err = "cannot allocate memory";
+		bch_err(c, "cannot allocate memory");
 		break;
 	case -EIO:
-		err = "IO error";
+		bch_err(c, "IO error");
 		break;
 	}
 
@@ -1394,7 +1389,7 @@ static void __bch2_dev_read_only(struct bch_fs *c, struct bch_dev *ca)
 	bch2_copygc_start(c);
 }
 
-static const char *__bch2_dev_read_write(struct bch_fs *c, struct bch_dev *ca)
+static int __bch2_dev_read_write(struct bch_fs *c, struct bch_dev *ca)
 {
 	lockdep_assert_held(&c->state_lock);
 
@@ -1403,10 +1398,7 @@ static const char *__bch2_dev_read_write(struct bch_fs *c, struct bch_dev *ca)
 	bch2_dev_allocator_add(c, ca);
 	bch2_recalc_capacity(c);
 
-	if (bch2_dev_allocator_start(ca))
-		return "error starting allocator thread";
-
-	return NULL;
+	return bch2_dev_allocator_start(ca);
 }
 
 int __bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
@@ -1432,9 +1424,8 @@ int __bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 	bch2_write_super(c);
 	mutex_unlock(&c->sb_lock);
 
-	if (new_state == BCH_MEMBER_STATE_rw &&
-	    __bch2_dev_read_write(c, ca))
-		ret = -ENOMEM;
+	if (new_state == BCH_MEMBER_STATE_rw)
+		ret = __bch2_dev_read_write(c, ca);
 
 	rebalance_wakeup(c);
 
@@ -1718,8 +1709,8 @@ have_slot:
 		goto err_late;
 
 	if (ca->mi.state == BCH_MEMBER_STATE_rw) {
-		err = __bch2_dev_read_write(c, ca);
-		if (err)
+		ret = __bch2_dev_read_write(c, ca);
+		if (ret)
 			goto err_late;
 	}
 
@@ -1763,24 +1754,27 @@ int bch2_dev_online(struct bch_fs *c, const char *path)
 	dev_idx = sb.sb->dev_idx;
 
 	err = bch2_dev_in_fs(c->disk_sb.sb, sb.sb);
-	if (err)
-		goto err;
-
-	if (bch2_dev_attach_bdev(c, &sb)) {
-		err = "bch2_dev_attach_bdev() error";
+	if (err) {
+		bch_err(c, "error bringing %s online: %s", path, err);
 		goto err;
 	}
 
+	ret = bch2_dev_attach_bdev(c, &sb);
+	if (ret)
+		goto err;
+
 	ca = bch_dev_locked(c, dev_idx);
 
-	if (bch2_trans_mark_dev_sb(c, ca)) {
-		err = "bch2_trans_mark_dev_sb() error";
+	ret = bch2_trans_mark_dev_sb(c, ca);
+	if (ret) {
+		bch_err(c, "error bringing %s online: error %i from bch2_trans_mark_dev_sb",
+			path, ret);
 		goto err;
 	}
 
 	if (ca->mi.state == BCH_MEMBER_STATE_rw) {
-		err = __bch2_dev_read_write(c, ca);
-		if (err)
+		ret = __bch2_dev_read_write(c, ca);
+		if (ret)
 			goto err;
 	}
 
@@ -1798,7 +1792,6 @@ int bch2_dev_online(struct bch_fs *c, const char *path)
 err:
 	up_write(&c->state_lock);
 	bch2_free_super(&sb);
-	bch_err(c, "error bringing %s online: %s", path, err);
 	return -EINVAL;
 }
 
@@ -1902,7 +1895,7 @@ struct bch_fs *bch2_fs_open(char * const *devices, unsigned nr_devices,
 	struct bch_sb_field_members *mi;
 	unsigned i, best_sb = 0;
 	const char *err;
-	int ret = -ENOMEM;
+	int ret = 0;
 
 	pr_verbose_init(opts, "");
 
@@ -1917,8 +1910,10 @@ struct bch_fs *bch2_fs_open(char * const *devices, unsigned nr_devices,
 	}
 
 	sb = kcalloc(nr_devices, sizeof(*sb), GFP_KERNEL);
-	if (!sb)
+	if (!sb) {
+		ret = -ENOMEM;
 		goto err;
+	}
 
 	for (i = 0; i < nr_devices; i++) {
 		ret = bch2_read_super(devices[i], &opts, &sb[i]);
@@ -1961,13 +1956,14 @@ struct bch_fs *bch2_fs_open(char * const *devices, unsigned nr_devices,
 		goto err;
 	}
 
-	err = "bch2_dev_online() error";
 	down_write(&c->state_lock);
-	for (i = 0; i < nr_devices; i++)
-		if (bch2_dev_attach_bdev(c, &sb[i])) {
+	for (i = 0; i < nr_devices; i++) {
+		ret = bch2_dev_attach_bdev(c, &sb[i]);
+		if (ret) {
 			up_write(&c->state_lock);
-			goto err_print;
+			goto err;
 		}
+	}
 	up_write(&c->state_lock);
 
 	err = "insufficient devices";
@@ -1992,8 +1988,9 @@ err_print:
 err:
 	if (!IS_ERR_OR_NULL(c))
 		bch2_fs_stop(c);
-	for (i = 0; i < nr_devices; i++)
-		bch2_free_super(&sb[i]);
+	if (sb)
+		for (i = 0; i < nr_devices; i++)
+			bch2_free_super(&sb[i]);
 	c = ERR_PTR(ret);
 	goto out;
 }

--- a/fs/bcachefs/super.c
+++ b/fs/bcachefs/super.c
@@ -638,12 +638,15 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	struct bch_fs *c;
 	unsigned i, iter_size;
 	const char *err;
+	int ret = 0;
 
 	pr_verbose_init(opts, "");
 
 	c = kvpmalloc(sizeof(struct bch_fs), GFP_KERNEL|__GFP_ZERO);
-	if (!c)
+	if (!c) {
+		c = ERR_PTR(-ENOMEM);
 		goto out;
+	}
 
 	__module_get(THIS_MODULE);
 
@@ -724,13 +727,16 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 
 	mutex_init(&c->sectors_available_lock);
 
-	if (percpu_init_rwsem(&c->mark_lock))
+	if (percpu_init_rwsem(&c->mark_lock)) {
+		ret = -ENOMEM;
 		goto err;
+	}
 
 	mutex_lock(&c->sb_lock);
 
 	if (bch2_sb_to_fs(c, sb)) {
 		mutex_unlock(&c->sb_lock);
+		ret = -ENOMEM;
 		goto err;
 	}
 
@@ -745,8 +751,10 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	c->block_bits		= ilog2(c->opts.block_size);
 	c->btree_foreground_merge_threshold = BTREE_FOREGROUND_MERGE_THRESHOLD(c);
 
-	if (bch2_fs_init_fault("fs_alloc"))
+	if (bch2_fs_init_fault("fs_alloc")) {
+		ret = -ENOMEM;
 		goto err;
+	}
 
 	iter_size = sizeof(struct sort_iter) +
 		(btree_blocks(c) + 1) * 2 *
@@ -787,10 +795,15 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	    bch2_fs_btree_interior_update_init(c) ||
 	    bch2_fs_subvolumes_init(c) ||
 	    bch2_fs_io_init(c) ||
-	    bch2_fs_encryption_init(c) ||
 	    bch2_fs_compress_init(c) ||
 	    bch2_fs_ec_init(c) ||
-	    bch2_fs_fsio_init(c))
+	    bch2_fs_fsio_init(c)) {
+		ret = -ENOMEM;
+		goto err;
+	}
+
+	ret = bch2_fs_encryption_init(c);
+	if (ret)
 		goto err;
 
 	if (c->opts.nochanges)
@@ -799,8 +812,10 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	mi = bch2_sb_get_members(c->disk_sb.sb);
 	for (i = 0; i < c->sb.nr_devices; i++)
 		if (bch2_dev_exists(c->disk_sb.sb, mi, i) &&
-		    bch2_dev_alloc(c, i))
+		    bch2_dev_alloc(c, i)) {
+			ret = -ENOMEM;
 			goto err;
+		}
 
 	bch2_journal_entry_res_resize(&c->journal,
 			&c->btree_root_journal_res,
@@ -815,14 +830,15 @@ static struct bch_fs *bch2_fs_alloc(struct bch_sb *sb, struct bch_opts opts)
 	mutex_unlock(&bch_fs_list_lock);
 	if (err) {
 		bch_err(c, "bch2_fs_online() error: %s", err);
+		ret = -ENOMEM;
 		goto err;
 	}
 out:
-	pr_verbose_init(opts, "ret %i", c ? 0 : -ENOMEM);
+	pr_verbose_init(opts, "ret %i", PTR_ERR_OR_ZERO(c));
 	return c;
 err:
 	bch2_fs_free(c);
-	c = NULL;
+	c = ERR_PTR(ret);
 	goto out;
 }
 
@@ -1939,10 +1955,11 @@ struct bch_fs *bch2_fs_open(char * const *devices, unsigned nr_devices,
 		i++;
 	}
 
-	ret = -ENOMEM;
 	c = bch2_fs_alloc(sb[best_sb].sb, opts);
-	if (!c)
+	if (IS_ERR(c)) {
+		ret = PTR_ERR(c);
 		goto err;
+	}
 
 	err = "bch2_dev_online() error";
 	down_write(&c->state_lock);
@@ -1973,7 +1990,7 @@ err_print:
 	       devices[0], err);
 	ret = -EINVAL;
 err:
-	if (c)
+	if (!IS_ERR_OR_NULL(c))
 		bch2_fs_stop(c);
 	for (i = 0; i < nr_devices; i++)
 		bch2_free_super(&sb[i]);
@@ -2002,12 +2019,12 @@ static const char *__bch2_fs_open_incremental(struct bch_sb_handle *sb,
 		if (err)
 			goto err;
 	} else {
-		c = bch2_fs_alloc(sb->sb, opts);
-		err = "cannot allocate memory";
-		if (!c)
-			goto err;
-
 		allocated_fs = true;
+		c = bch2_fs_alloc(sb->sb, opts);
+
+		err = "bch2_fs_alloc() error";
+		if (IS_ERR(c))
+			goto err;
 	}
 
 	err = "bch2_dev_online() error";
@@ -2033,7 +2050,7 @@ static const char *__bch2_fs_open_incremental(struct bch_sb_handle *sb,
 err:
 	mutex_unlock(&bch_fs_list_lock);
 
-	if (allocated_fs)
+	if (allocated_fs && !IS_ERR(c))
 		bch2_fs_stop(c);
 	else if (c)
 		closure_put(&c->cl);


### PR DESCRIPTION
NFS was disabled due to be incompatible with snapshot-enabled bcachefs filesystem.
When we limit NFS to the active snapshot (1), it could still be used.
Nonetherless, a lot of investigations are still needed to make it failproof for all new bcachefs features,
but at least users deploying bcachefs on a NAS can use it again.

Signed-off-by: jpsollie <janpieter.sollie@edpnet.be>