### PR TITLE
bcachefs: Make bch_option compatible with Rust ffi

### DIFF
--- a/fs/bcachefs/opts.h
+++ b/fs/bcachefs/opts.h
@@ -449,17 +449,9 @@ struct bch_option {
 	enum opt_flags		flags;
 	u64			min, max;
 
-	union {
-	struct {
-	};
-	struct {
-		const char * const *choices;
-	};
-	struct {
-		int (*parse)(struct bch_fs *, const char *, u64 *);
-		void (*to_text)(struct printbuf *, struct bch_fs *, struct bch_sb *, u64);
-	};
-	};
+	const char * const *choices;
+	int (*parse)(struct bch_fs *, const char *, u64 *);
+	void (*to_text)(struct printbuf *, struct bch_fs *, struct bch_sb *, u64);
 
 	const char		*hint;
 	const char		*help;


### PR DESCRIPTION
Continuation of https://github.com/koverstreet/bcachefs-tools/pull/123

Currently -tools build warns:
```
make mount.bcachefs -j4           
LIBBCACHEFS_LIB=/home/holmanb/workspace/bcachefs-tools \
LIBBCACHEFS_INCLUDE=/home/holmanb/workspace/bcachefs-tools \
cargo  build --release --manifest-path rust-src/mount/Cargo.toml
   Compiling bch_bindgen v0.1.0 (/home/holmanb/workspace/bcachefs-tools/rust-src/bch_bindgen)
error[E0587]: type has conflicting packed and align representation hints
 --> /home/holmanb/workspace/bcachefs-tools/rust-src/mount/target/release/build/bch_bindgen-9a46f64534408994/out/bcachefs.rs:3:131408
  |
3 | ... ] pub struct bkey { pub u64s : __u8 , pub _bitfield_align_1 : [ u8 ; 0 ] , pub _bitfield_1 : __BindgenBitfieldUnit < [ u8 ; 1usize ] > , pub type_ : __u8 , pub pad : [ __u8 ; 1usize ] , pub version : bversion , pub size : __u32 , pub p : bpos , } # ...
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0587`.
error: could not compile `bch_bindgen` due to previous error
make: *** [Makefile:122: mount.bcachefs] Error 101
```

Removing the use of anonymous structs and unions in bch_options removes the error and will allow future use via rust ffi.