### PR TITLE
lib/vsprintf: EXPORT_SYMBOL_GPL(prt_u64)

### DIFF
--- a/lib/vsprintf.c
+++ b/lib/vsprintf.c
@@ -400,6 +400,7 @@ void prt_u64(struct printbuf *out, u64 num)
 {
 	prt_u64_minwidth(out, num, 0);
 }
+EXPORT_SYMBOL_GPL(prt_u64);
 
 /*
  * Convert passed number to decimal string.


### PR DESCRIPTION
bcachefs uses prt_u64(), so export it.

Signed-off-by: Pascal Ernster <git@hardfalcon.net>