### PR TITLE
bcachefs: Fix memleak in replicas_table_update()

### DIFF
--- a/fs/bcachefs/replicas.c
+++ b/fs/bcachefs/replicas.c
@@ -304,13 +304,6 @@ static int replicas_table_update(struct bch_fs *c,
 					sizeof(u64), GFP_KERNEL)))
 			goto err;
 
-	memset(new_usage, 0, sizeof(new_usage));
-
-	for (i = 0; i < ARRAY_SIZE(new_usage); i++)
-		if (!(new_usage[i] = __alloc_percpu_gfp(bytes,
-					sizeof(u64), GFP_KERNEL)))
-			goto err;
-
 	if (!(new_base = kzalloc(bytes, GFP_KERNEL)) ||
 	    !(new_scratch  = kmalloc(scratch_bytes, GFP_KERNEL)) ||
 	    (c->usage_gc &&


### PR DESCRIPTION
See the duplicate allocations to `new_usage` on line 310.

This was introduced in [this commit](https://github.com/koverstreet/bcachefs/commit/58cf276433345330f8c709cb94adbce4347e8870#diff-30d84dfaefcc8b992691df8e6982beee47c06c703ca21316a64aea6124b78ee1). 