### PR TITLE
bcachefs: Fix `bch2_fs_get_tree()` error path

### DIFF
--- a/fs/bcachefs/fs.c
+++ b/fs/bcachefs/fs.c
@@ -2290,7 +2290,8 @@ err_stop_fs:
 	goto err;
 
 err_put_super:
-	__bch2_fs_stop(c);
+	if (!sb->s_root)
+		__bch2_fs_stop(c);
 	deactivate_locked_super(sb);
 	goto err;
 }


### PR DESCRIPTION
When a filesystem is mounted read-only, subsequent attempts to mount it as read-write fail with `EBUSY`. Previously, the error path in `bch2_fs_get_tree()` would unconditionally call `__bch2_fs_stop()`, improperly freeing resources for a filesystem that was still actively mounted. This change modifies the error path to only call `__bch2_fs_stop()` if the superblock has no valid root dentry, ensuring resources are not cleaned up prematurely when the filesystem is in use.

ktest:
```sh
test_mount_again_after_ebusy()
{
    set_watchdog 10

    run_quiet "" bcachefs format -f --errors=panic ${ktest_scratch_dev[0]}
    echo "test: mount ro"
    mount -t bcachefs -o ro ${ktest_scratch_dev[0]} /mnt

    mkdir -p /mnt2
    echo "test: try mount rw (1)"
    ! mount -t bcachefs ${ktest_scratch_dev[0]} /mnt2
    echo "test: try mount rw (2)"
    ! mount -t bcachefs ${ktest_scratch_dev[0]} /mnt2

    umount /mnt

    bcachefs fsck -ny ${ktest_scratch_dev[0]}
    bcachefs_test_end_checks ${ktest_scratch_dev[0]}
}
```
(I'll submit this to the ktest repo soon.)

Fixes #840.