### PR TITLE
bcachefs: Expose additional features in DKMS builds

### DIFF
--- a/fs/bcachefs/Makefile
+++ b/fs/bcachefs/Makefile
@@ -1,7 +1,9 @@
 
 ifdef BCACHEFS_DKMS
 	CONFIG_BCACHEFS_FS := m
-	# Enable other features here?
+	# Enable other features here
+	subdir-ccflags-$(CONFIG_BCACHEFS_QUOTA) += -DCONFIG_BCACHEFS_QUOTA=1
+	subdir-ccflags-$(CONFIG_BCACHEFS_ERASURE_CODING) += -DCONFIG_BCACHEFS_ERASURE_CODING=1
 endif
 
 obj-$(CONFIG_BCACHEFS_FS)	+= bcachefs.o


### PR DESCRIPTION
Allow DKMS builds to enable quota and erasure coding by passing `CONFIG_BCACHEFS_QUOTA=y` and `CONFIG_BCACHEFS_ERASURE_CODING=y` to the make command.

I've focused on the prominent user features. Let me know if you want to expose debug switches as well.