### PR TITLE
bcachefs: don't hold srcu lock across blocking operations

### DIFF
--- a/fs/bcachefs/alloc/foreground.c
+++ b/fs/bcachefs/alloc/foreground.c
@@ -54,7 +54,7 @@ static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)
 {
 	if (!mutex_trylock(lock)) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		mutex_lock(lock);
 	}
 }

--- a/fs/bcachefs/btree/cache.c
+++ b/fs/bcachefs/btree/cache.c
@@ -861,7 +861,7 @@ struct btree *bch2_btree_node_mem_alloc(struct btree_trans *trans, bool pcpu_rea
 		bch2_btree_lock_init(&b->c, pcpu_read_locks ? SIX_LOCK_INIT_PCPU : 0, GFP_NOWAIT);
 	} else {
 		mutex_unlock(&bc->lock);
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		b = __btree_node_mem_alloc(c, GFP_KERNEL);
 		if (!b)
 			goto err;
@@ -895,7 +895,7 @@ got_node:
 	mutex_unlock(&bc->lock);
 
 	if (btree_node_data_alloc(c, b, GFP_NOWAIT, true)) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		if (btree_node_data_alloc(c, b, GFP_KERNEL|__GFP_NOWARN, true)) {
 			__btree_node_data_free(b);
 			goto err;
@@ -1030,7 +1030,7 @@ static noinline struct btree *bch2_btree_node_fill(struct btree_trans *trans,
 
 			/* Unlock before doing IO: */
 			six_unlock_intent(&b->c.lock);
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 
 			bch2_btree_node_read(trans, b, sync);
 
@@ -1168,7 +1168,7 @@ retry:
 		u32 seq = six_lock_seq(&b->c.lock);
 
 		six_unlock_type(&b->c.lock, lock_type);
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		bch2_btree_node_wait_on_read(b);
 

--- a/fs/bcachefs/btree/commit.c
+++ b/fs/bcachefs/btree/commit.c
@@ -429,7 +429,7 @@ btree_key_can_insert_cached_slowpath(struct btree_trans *trans, unsigned flags,
 	int ret;
 
 	bch2_trans_unlock_updates_write(trans);
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	new_k = kmalloc(new_u64s * sizeof(u64), GFP_KERNEL);
 	if (!new_k) {
@@ -945,7 +945,7 @@ static int __bch2_trans_commit_error(struct btree_trans *trans, unsigned flags,
 		    watermark < BCH_WATERMARK_reclaim)
 			return bch_err_throw(c, journal_reclaim_would_deadlock);
 
-		return drop_locks_do(trans,
+		return drop_locks_long_do(trans,
 			bch2_trans_journal_res_get(trans,
 					(flags & BCH_WATERMARK_MASK)|
 					JOURNAL_RES_GET_CHECK));
@@ -970,7 +970,7 @@ static int __bch2_trans_commit_error(struct btree_trans *trans, unsigned flags,
 	case -BCH_ERR_btree_insert_need_mark_replicas:
 		return drop_locks_do(trans, bch2_accounting_update_sb(trans));
 	case -BCH_ERR_btree_insert_need_journal_reclaim:
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		event_inc_trace(c, trans_blocked_journal_reclaim, buf, ({
 			prt_printf(&buf, "%s\n", trans->fn);

--- a/fs/bcachefs/btree/interior.c
+++ b/fs/bcachefs/btree/interior.c
@@ -834,7 +834,7 @@ static void btree_update_nodes_written(struct btree_update *as)
 	 * which may require allocations as well.
 	 */
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	/*
 	 * btree_interior_update_commit_lock is needed for synchronization with
 	 * btree_node_update_key(): having the lock be at the filesystem level
@@ -1221,7 +1221,7 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 		if (commit_flags & BCH_TRANS_COMMIT_journal_reclaim)
 			return ERR_PTR(-BCH_ERR_journal_reclaim_would_deadlock);
 
-		ret = drop_locks_do(trans,
+		ret = drop_locks_long_do(trans,
 			({ wait_event(c->journal.wait, !journal_low_on_space(&c->journal)); 0; }));
 		if (ret)
 			return ERR_PTR(ret);
@@ -1254,7 +1254,7 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 	}
 
 	if (!down_read_trylock(&c->gc.lock)) {
-		ret = drop_locks_do(trans, (down_read(&c->gc.lock), 0));
+		ret = drop_locks_long_do(trans, (down_read(&c->gc.lock), 0));
 		if (ret) {
 			up_read(&c->gc.lock);
 			return ERR_PTR(ret);
@@ -1348,7 +1348,7 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 			ret = bch2_btree_reserve_get(trans, as, nr_nodes, req);
 			if (!bch2_err_matches(ret, BCH_ERR_operation_blocked))
 				break;
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 			bch2_wait_on_allocator(c, req, ret, &cl);
 		} while (1);
 
@@ -1359,7 +1359,7 @@ bch2_btree_update_start(struct btree_trans *trans, struct btree_path *path,
 		 * without waking up the waitlist:
 		 */
 		if (closure_nr_remaining(&cl) > 1)
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 	}
 
 	if (ret) {

--- a/fs/bcachefs/btree/iter.h
+++ b/fs/bcachefs/btree/iter.h
@@ -1035,6 +1035,17 @@ struct bkey_s_c bch2_btree_iter_peek_root(struct btree_trans *, struct btree_ite
 	(_do) ?: bch2_trans_relock(_trans);				\
 })
 
+/*
+ * Like drop_locks_do, but also drops the SRCU read lock so that SRCU grace
+ * periods can complete and the shrinker can free old btree nodes.  Use before
+ * operations that may block for an extended/unbounded time.
+ */
+#define drop_locks_long_do(_trans, _do)					\
+({									\
+	bch2_trans_unlock_long(_trans);					\
+	(_do) ?: bch2_trans_relock(_trans);				\
+})
+
 #define allocate_dropping_locks_errcode(_trans, _do)			\
 ({									\
 	gfp_t _gfp = GFP_NOWAIT;					\

--- a/fs/bcachefs/btree/locking.c
+++ b/fs/bcachefs/btree/locking.c
@@ -899,7 +899,7 @@ void bch2_trans_unlock_write(struct btree_trans *trans)
 int __bch2_trans_mutex_lock(struct btree_trans *trans,
 			    struct mutex *lock)
 {
-	int ret = drop_locks_do(trans, (mutex_lock(lock), 0));
+	int ret = drop_locks_long_do(trans, (mutex_lock(lock), 0));
 
 	if (ret)
 		mutex_unlock(lock);

--- a/fs/bcachefs/btree/read.c
+++ b/fs/bcachefs/btree/read.c
@@ -1100,7 +1100,7 @@ static int __bch2_btree_root_read(struct btree_trans *trans, enum btree_id id,
 	set_btree_node_read_in_flight(b);
 
 	/* we can't pass the trans to read_done() for fsck errors, so it must be unlocked */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	bch2_btree_node_read(trans, b, true);
 
 	if (btree_node_read_error(b)) {

--- a/fs/bcachefs/data/ec/io.c
+++ b/fs/bcachefs/data/ec/io.c
@@ -538,7 +538,7 @@ int bch2_ec_read_extent(struct btree_trans *trans, struct bch_read_bio *rbio,
 	}
 
 	/* Don't hold btree locks for stripe buffer allocations, or IO */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	ret = bch2_ec_stripe_buf_init(c, buf, offset, bio_sectors(&rbio->bio));
 	if (ret) {

--- a/fs/bcachefs/data/migrate.c
+++ b/fs/bcachefs/data/migrate.c
@@ -188,7 +188,7 @@ static int bch2_dev_metadata_drop(struct bch_fs *c,
 			bch2_btree_iter_next_node(&iter);
 	}
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	bch2_btree_interior_updates_flush(c);
 
 	BUG_ON(bch2_err_matches(ret, BCH_ERR_transaction_restart));

--- a/fs/bcachefs/data/update.c
+++ b/fs/bcachefs/data/update.c
@@ -772,7 +772,7 @@ int bch2_update_unwritten_extent(struct btree_trans *trans,
 				update->op.watermark,
 				0, &cl, &wp);
 		if (bch2_err_matches(ret, BCH_ERR_operation_blocked)) {
-			bch2_trans_unlock(trans);
+			bch2_trans_unlock_long(trans);
 			closure_sync(&cl);
 			continue;
 		}
@@ -805,7 +805,7 @@ int bch2_update_unwritten_extent(struct btree_trans *trans,
 	}
 
 	if (closure_nr_remaining(&cl) != 1) {
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 		closure_sync(&cl);
 	}
 
@@ -1386,7 +1386,7 @@ int bch2_data_update_init(struct btree_trans *trans,
 		goto out_nocow_unlock;
 	}
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	ret = bch2_data_update_bios_init(m, c, io_opts, buf_bytes);
 	if (ret)

--- a/fs/bcachefs/data/write.c
+++ b/fs/bcachefs/data/write.c
@@ -2135,7 +2135,7 @@ retry:
 		k = bkey_i_to_s_c(op->insert_keys.top);
 		ptrs = bch2_bkey_ptrs_c(k);
 
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
 		bch2_bkey_nocow_lock(c, ptrs, ~0U, BUCKET_NOCOW_LOCK_UPDATE);
 

--- a/fs/bcachefs/debug/tests.c
+++ b/fs/bcachefs/debug/tests.c
@@ -82,7 +82,7 @@ static int test_delete_written(struct bch_fs *c, u64 nr)
 	if (ret)
 		return ret;
 
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 	bch2_journal_flush_outstanding_pins(&c->journal);
 
 	ret = commit_do(trans, NULL, NULL, 0,

--- a/fs/bcachefs/init/error.c
+++ b/fs/bcachefs/init/error.c
@@ -220,27 +220,16 @@ static enum ask_yn bch2_fsck_ask_yn(struct bch_fs *c, struct btree_trans *trans)
 		return YN_NO;
 
 	if (trans)
-		bch2_trans_unlock(trans);
+		bch2_trans_unlock_long(trans);
 
-	unsigned long unlock_long_at = trans ? jiffies + HZ * 2 : 0;
 	darray_char line = {};
 	int ret;
 
 	do {
-		unsigned long t;
 		bch2_print(c, " (y,n, or Y,N for all errors of this type) ");
-rewait:
-		t = unlock_long_at
-			? max_t(long, unlock_long_at - jiffies, 0)
-			: MAX_SCHEDULE_TIMEOUT;
 
-		int r = bch2_stdio_redirect_readline_timeout(stdio, &line, t);
-		if (r == -ETIME) {
-			bch2_trans_unlock_long(trans);
-			unlock_long_at = 0;
-			goto rewait;
-		}
-
+		int r = bch2_stdio_redirect_readline_timeout(stdio, &line,
+							     MAX_SCHEDULE_TIMEOUT);
 		if (r < 0) {
 			ret = YN_NO;
 			break;

--- a/fs/bcachefs/vfs/buffered.c
+++ b/fs/bcachefs/vfs/buffered.c
@@ -115,7 +115,7 @@ static int readpage_bio_extend(struct btree_trans *trans,
 			       bool get_more)
 {
 	/* Don't hold btree locks while allocating memory: */
-	bch2_trans_unlock(trans);
+	bch2_trans_unlock_long(trans);
 
 	while (bio_sectors(bio) < sectors_this_extent &&
 	       bio->bi_vcnt < bio->bi_max_vecs) {

--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -355,7 +355,7 @@ repeat:
 			if (!trans) {
 				__wait_on_freeing_inode(c, inode, inum);
 			} else {
-				int ret = drop_locks_do(trans,
+				int ret = drop_locks_long_do(trans,
 						(__wait_on_freeing_inode(c, inode, inum), 0));
 				if (ret)
 					return ERR_PTR(ret);


### PR DESCRIPTION
Audit and fix 25 sites where `bch2_trans_unlock()` (which only drops btree locks) is used before a potentially long-blocking operation, leaving the SRCU read lock held. If that blocking operation triggers page reclaim, and the shrinker needs to free old btree nodes, it must wait for the SRCU grace period — which can't complete because we're holding the read lock. This creates a reclaim deadlock under memory pressure.

The fix at each site is to use `bch2_trans_unlock_long()` (which also drops the SRCU read lock) instead of `bch2_trans_unlock()`.

Also introduces `drop_locks_long_do()` — the SRCU-dropping variant of `drop_locks_do()`.

---

### Update (2026-03-27): rebased and simplified

The branch has been rebased onto current master and the commit message updated with benchmark evidence.

The earlier stacked branch (`fix/drop-srcu-before-data-update-alloc`) explored an additional `srcu_escalation_timeout_ms` mechanism with `bch2_trans_srcu_unlock_if_elapsed()` at 13 secondary callsites. **Extensive benchmarking showed this mechanism has no measurable effect** and has been dropped from this PR:

- 30+ QEMU runs with dm-delay (50–200ms) on all devices
- Timeout values from 0ms (always drop) to infinity (never drop at secondary sites)
- 200–500ms artificial delays injected at all 13 `bch2_trans_srcu_unlock_if_elapsed()` callsites
- **Result: identical throughput in all cases** (~22k file ops/60s, 0 stalls, all clean shutdown)

The unconditional `bch2_trans_unlock_long()` at the 25 blocking boundaries is both necessary and sufficient.

---

Triggered by a full system deadlock on a 128 GB machine with bcachefs as root on tiered SSD+HDD storage, where the reconcile thread held SRCU for 13+ seconds during `GFP_KERNEL` bio allocation in `bch2_data_update_init()`.

15 files changed, 25 sites fixed, net zero lines changed.

Investigation notes [INVESTIGATION.md](https://github.com/matthiasgoergens/bcachefs/blob/fix/drop-srcu-before-data-update-alloc/INVESTIGATION.md), full audit, GitHub issue survey, and a QEMU-based reproducer are on the stacked branch [fix/drop-srcu-before-data-update-alloc](https://github.com/matthiasgoergens/bcachefs/tree/fix/drop-srcu-before-data-update-alloc).

Related: #934
Related: #936
Related: #882
Related: #636
Related: #605
Related: #826
Related: #811
Related: #1016
