### PR TITLE
bcachefs: Add support for shrinking filesystems

### DIFF
--- a/fs/bcachefs/alloc/background.c
+++ b/fs/bcachefs/alloc/background.c
@@ -982,6 +982,89 @@ int bch2_dev_remove_alloc(struct bch_fs *c, struct bch_dev *ca)
 	return ret;
 }
 
+/* device shrink */
+
+struct dev_shrink_acct {
+	u64	buckets;
+	u64	sectors;
+};
+
+int bch2_dev_shrink_alloc(struct bch_fs *c, struct bch_dev *ca,
+			  u64 new_nbuckets, u64 old_nbuckets)
+{
+	struct bpos start	= POS(ca->dev_idx, new_nbuckets);
+	struct bpos end		= POS(ca->dev_idx, old_nbuckets);
+	struct dev_shrink_acct per_type[BCH_DATA_NR] = {};
+	int ret;
+
+	/*
+	 * Clear LRU entries for buckets being removed so that we don't race
+	 * with bch2_do_invalidates() and bch2_do_discards()
+	 */
+	ret = bch2_dev_shrink_lrus(c, ca, new_nbuckets);
+	if (ret)
+		goto err;
+
+	/* First pass: count buckets and sectors of each data type being removed */
+	{
+		CLASS(btree_trans, trans)(c);
+		ret = for_each_btree_key(trans, iter, BTREE_ID_alloc, start,
+				BTREE_ITER_prefetch, k, ({
+			if (bkey_ge(k.k->p, end))
+				break;
+
+			struct bch_alloc_v4 a_convert;
+			const struct bch_alloc_v4 *a = bch2_alloc_to_v4(k, &a_convert);
+
+			if (a->data_type < BCH_DATA_NR) {
+				per_type[a->data_type].buckets++;
+				per_type[a->data_type].sectors += a->dirty_sectors;
+			}
+			0;
+		}));
+		if (ret)
+			goto err;
+	}
+
+	/* Count buckets with no alloc entry as free */
+	{
+		u64 total_counted = 0;
+		for (unsigned i = 0; i < BCH_DATA_NR; i++)
+			total_counted += per_type[i].buckets;
+		per_type[BCH_DATA_free].buckets += (old_nbuckets - new_nbuckets) - total_counted;
+	}
+
+	/* Update disk accounting for removed buckets */
+	for (unsigned i = 0; i < BCH_DATA_NR; i++) {
+		if (!per_type[i].buckets)
+			continue;
+
+		u64 v[3] = { -(s64) per_type[i].buckets,
+			     -(s64) per_type[i].sectors, 0 };
+		ret = bch2_trans_commit_do(c, NULL, NULL, 0,
+			bch2_disk_accounting_mod2(trans, false, v, dev_data_type,
+						  .dev = ca->dev_idx,
+						  .data_type = i));
+		if (ret)
+			goto err;
+	}
+
+	/* Delete btree entries for removed buckets */
+	ret =	bch2_btree_delete_range(c, BTREE_ID_need_discard, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_freespace, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_backpointers, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_bucket_gens, start, end,
+					BTREE_TRIGGER_norun) ?:
+		bch2_btree_delete_range(c, BTREE_ID_alloc, start, end,
+					BTREE_TRIGGER_norun);
+err:
+	bch_err_msg_dev(ca, ret, "removing alloc info for shrink");
+	return ret;
+}
+
 /* Bucket IO clocks: */
 
 static int __bch2_bucket_io_time_reset(struct btree_trans *trans, unsigned dev,

--- a/fs/bcachefs/alloc/background.h
+++ b/fs/bcachefs/alloc/background.h
@@ -329,6 +329,7 @@ int bch2_trigger_alloc(struct btree_trans *, enum btree_id, unsigned,
 		       enum btree_iter_update_trigger_flags);
 
 int bch2_dev_remove_alloc(struct bch_fs *, struct bch_dev *);
+int bch2_dev_shrink_alloc(struct bch_fs *, struct bch_dev *, u64, u64);
 
 void bch2_recalc_capacity(struct bch_fs *);
 u64 bch2_min_rw_member_capacity(struct bch_fs *);

--- a/fs/bcachefs/alloc/lru.c
+++ b/fs/bcachefs/alloc/lru.c
@@ -135,6 +135,26 @@ int bch2_dev_remove_lrus(struct bch_fs *c, struct bch_dev *ca)
 	return ret;
 }
 
+int bch2_dev_shrink_lrus(struct bch_fs *c, struct bch_dev *ca,
+			 u64 new_nbuckets)
+{
+	CLASS(btree_trans, trans)(c);
+	int ret = bch2_btree_write_buffer_flush_sync(trans) ?:
+		for_each_btree_key(trans, iter,
+				 BTREE_ID_lru, POS_MIN, BTREE_ITER_prefetch, k, ({
+		struct bbpos bp = lru_pos_to_bp(k);
+
+		bp.btree == BTREE_ID_alloc &&
+		bp.pos.inode == ca->dev_idx &&
+		bp.pos.offset >= new_nbuckets
+		? (bch2_btree_delete_at(trans, &iter, 0) ?:
+		   bch2_trans_commit(trans, NULL, NULL, 0))
+		: 0;
+	}));
+	bch_err_msg_dev(ca, ret, "removing LRU entries for shrink");
+	return ret;
+}
+
 static u64 bkey_lru_type_idx(struct bch_fs *c,
 			     enum bch_lru_type type,
 			     struct bkey_s_c k)

--- a/fs/bcachefs/alloc/lru.h
+++ b/fs/bcachefs/alloc/lru.h
@@ -71,6 +71,7 @@ static inline int bch2_lru_change(struct btree_trans *trans,
 }
 
 int bch2_dev_remove_lrus(struct bch_fs *, struct bch_dev *);
+int bch2_dev_shrink_lrus(struct bch_fs *, struct bch_dev *, u64);
 
 struct wb_maybe_flush;
 int bch2_lru_check_set(struct btree_trans *, u16, u64, u64, struct bkey_s_c,

--- a/fs/bcachefs/data/move.c
+++ b/fs/bcachefs/data/move.c
@@ -669,6 +669,17 @@ int bch2_evacuate_data(struct moving_context *ctxt,
 				     evacuate_pred, &arg);
 }
 
+int bch2_evacuate_phys(struct bch_fs *c, unsigned dev, u64 start, u64 end)
+{
+	struct evacuate_arg arg = { .dev = dev };
+
+	return bch2_move_data_phys(c, dev, start, end,
+				   ~0U, NULL, NULL,
+				   writepoint_hashed(0),
+				   true,
+				   evacuate_pred, &arg);
+}
+
 static int evacuate_bucket_pred(struct btree_trans *trans, void *_arg,
 				enum btree_id btree, struct bkey_s_c k,
 				struct bch_inode_opts *io_opts,

--- a/fs/bcachefs/data/move.h
+++ b/fs/bcachefs/data/move.h
@@ -119,6 +119,7 @@ int bch2_move_data_phys(struct bch_fs *, unsigned, u64, u64, unsigned,
 			move_pred_fn, void *);
 
 int bch2_evacuate_data(struct moving_context *, unsigned, u64, u64);
+int bch2_evacuate_phys(struct bch_fs *, unsigned, u64, u64);
 
 int bch2_evacuate_bucket(struct moving_context *,
 			   struct move_bucket *,

--- a/fs/bcachefs/init/dev.c
+++ b/fs/bcachefs/init/dev.c
@@ -10,8 +10,11 @@
 
 #include "btree/interior.h"
 
+#include "alloc/buckets.h"
+
 #include "data/ec/init.h"
 #include "data/migrate.h"
+#include "data/move.h"
 #include "data/reconcile/work.h"
 
 #include "debug/sysfs.h"
@@ -1024,6 +1027,147 @@ int bch2_dev_offline(struct bch_fs *c, struct bch_dev *ca, int flags, struct pri
 	return 0;
 }
 
+static bool bucket_has_journal(struct bch_dev *ca, u64 b)
+{
+	for (unsigned i = 0; i < ca->journal.nr; i++)
+		if (b == ca->journal.buckets[i])
+			return true;
+	return false;
+}
+
+static int bch2_dev_shrink(struct bch_fs *c, struct bch_dev *ca,
+			   u64 nbuckets, u64 old_nbuckets,
+			   struct printbuf *err)
+{
+	u64 sector_start = bucket_to_sector(ca, nbuckets);
+	u64 sector_end	 = bucket_to_sector(ca, old_nbuckets);
+	int ret;
+
+	if (nbuckets <= ca->mi.first_bucket ||
+	    nbuckets - ca->mi.first_bucket < BCH_MIN_NR_NBUCKETS) {
+		prt_printf(err, "New size too small (minimum %u usable buckets)\n",
+			   BCH_MIN_NR_NBUCKETS);
+		return -EINVAL;
+	}
+
+	/* Check for journal buckets in the region being removed */
+	for (u64 b = nbuckets; b < old_nbuckets; b++) {
+		if (bucket_has_journal(ca, b)) {
+			prt_printf(err, "Cannot shrink: bucket %llu contains journal data\n", b);
+			return -EINVAL;
+		}
+	}
+
+	/*
+	 * Drop any superblock copies that fall in the region being removed.
+	 * The primary copies at the start of the device are preserved; backup
+	 * copies near the end are simply dropped.
+	 */
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+
+		struct bch_sb_layout *layout = &ca->disk_sb.sb->layout;
+		u64 sb_max_size = 1ULL << layout->sb_max_size_bits;
+		unsigned new_nr = 0;
+
+		for (unsigned i = 0; i < layout->nr_superblocks; i++) {
+			u64 offset = le64_to_cpu(layout->sb_offset[i]);
+			u64 end = offset + sb_max_size;
+
+			if (end <= sector_start)
+				layout->sb_offset[new_nr++] = layout->sb_offset[i];
+		}
+
+		if (new_nr < 1) {
+			prt_printf(err, "Cannot shrink: no superblock copies would remain\n");
+			return -EINVAL;
+		}
+
+		layout->nr_superblocks = new_nr;
+		bch2_write_super(c);
+	}
+
+	/*
+	 * From this point on, errors leave the filesystem in a recoverable
+	 * state: the superblock layout has fewer copies but nbuckets hasn't
+	 * changed yet, so the device is still its original size and the
+	 * remaining SB copies are in the preserved region.
+	 */
+
+	/*
+	 * Re-mark superblock and journal bucket locations in the alloc btree
+	 * after the layout change:
+	 */
+	ret = bch2_trans_mark_dev_sb(c, ca, BTREE_TRIGGER_transactional);
+	if (ret) {
+		prt_printf(err, "bch2_trans_mark_dev_sb() error: %s\n", bch2_err_str(ret));
+		return ret;
+	}
+
+	/* Evacuate data from the tail region */
+	ret = bch2_evacuate_phys(c, ca->dev_idx, sector_start, sector_end);
+	if (ret) {
+		prt_printf(err, "Error evacuating data: %s\n", bch2_err_str(ret));
+		return ret;
+	}
+
+	/* Verify that no movable data remains in the region being removed */
+	{
+		struct bpos start = POS(ca->dev_idx, nbuckets);
+		struct bpos end   = POS(ca->dev_idx, old_nbuckets);
+
+		CLASS(btree_trans, trans)(c);
+		ret = for_each_btree_key(trans, iter, BTREE_ID_alloc, start,
+				BTREE_ITER_prefetch, k, ({
+			if (bkey_ge(k.k->p, end))
+				break;
+
+			struct bch_alloc_v4 a_convert;
+			const struct bch_alloc_v4 *a = bch2_alloc_to_v4(k, &a_convert);
+
+			if (data_type_movable(a->data_type) && a->dirty_sectors) {
+				prt_printf(err, "Bucket %llu:%llu still has %u dirty sectors (type %s) after evacuation\n",
+					   k.k->p.inode, k.k->p.offset,
+					   a->dirty_sectors,
+					   __bch2_data_types[a->data_type]);
+				ret = -EINVAL;
+				break;
+			}
+			0;
+		}));
+		if (ret)
+			return ret;
+	}
+
+	/* Clean up alloc info for removed buckets */
+	if (ca->mi.freespace_initialized) {
+		ret = bch2_dev_shrink_alloc(c, ca, nbuckets, old_nbuckets);
+		if (ret) {
+			prt_printf(err, "bch2_dev_shrink_alloc() error: %s\n", bch2_err_str(ret));
+			return ret;
+		}
+	}
+
+	/* Shrink bucket_gens and related structures */
+	ret = bch2_dev_buckets_resize(c, ca, nbuckets);
+	if (ret) {
+		prt_printf(err, "bch2_dev_buckets_resize() error: %s\n", bch2_err_str(ret));
+		return ret;
+	}
+
+	/* Update superblock with new nbuckets */
+	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
+		guard(mutex)(&c->sb_lock);
+		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
+		m->nbuckets = cpu_to_le64(nbuckets);
+
+		bch2_write_super(c);
+	}
+
+	bch2_recalc_capacity(c);
+	return 0;
+}
+
 int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct printbuf *err)
 {
 	u64 old_nbuckets;
@@ -1032,10 +1176,8 @@ int bch2_dev_resize(struct bch_fs *c, struct bch_dev *ca, u64 nbuckets, struct p
 	guard(rwsem_write)(&c->state_lock);
 	old_nbuckets = ca->mi.nbuckets;
 
-	if (nbuckets < ca->mi.nbuckets) {
-		prt_printf(err, "Cannot shrink yet\n");
-		return -EINVAL;
-	}
+	if (nbuckets < ca->mi.nbuckets)
+		return bch2_dev_shrink(c, ca, nbuckets, old_nbuckets, err);
 
 	bool wakeup_reconcile_pending = nbuckets > ca->mi.nbuckets;
 	struct reconcile_scan s = { .type = RECONCILE_SCAN_pending };


### PR DESCRIPTION
Implements device shrink by evacuating data from the tail of the device, then
reducing nbuckets.  This piggybacks on the existing `bch2_move_data_phys()`
infrastructure used for device evacuation, so no new data movement code is
needed.

The sequence is: validate the new size, check that no journal buckets fall in
the removed region, drop any backup superblock copies that overlap it, re-mark
SB/journal buckets in the alloc btree, evacuate data from the tail, verify
nothing movable remains, clean up LRU/alloc/freespace/backpointer entries for
the removed buckets (with per-data-type accounting adjustments), shrink the
in-memory bucket structures, and write the new nbuckets to the superblock.

Limitations: journal buckets in the tail region block the shrink (the user
must shrink the journal first via `bcachefs device resize-journal`).  Online
shrink passes through the ioctl but has not been tested beyond offline
userspace fsck validation.

Closes: https://github.com/koverstreet/bcachefs/issues/781