### PR TITLE
bcachefs: Record device serial number in superblock

### DIFF
--- a/fs/bcachefs/init/dev.c
+++ b/fs/bcachefs/init/dev.c
@@ -686,6 +686,17 @@ static int __bch2_dev_attach_bdev(struct bch_fs *c, struct bch_dev *ca,
 	if (model.nr && model.data[model.nr - 1] == '\n')
 		model.data[--model.nr] = '\0';
 
+	CLASS(darray_char, serial)();
+	darray_make_room(&serial, 128);
+
+	CLASS(printbuf, serial_path)();
+	prt_printf(&serial_path, "/sys/block/%s/device/serial", name.buf);
+
+	read_file_str(serial_path.buf, &serial);
+
+	if (serial.nr && serial.data[serial.nr - 1] == '\n')
+		serial.data[--serial.nr] = '\0';
+
 	scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 		guard(mutex)(&c->sb_lock);
 		struct bch_member *m = bch2_members_v2_get_mut(c->disk_sb.sb, ca->dev_idx);
@@ -694,6 +705,9 @@ static int __bch2_dev_attach_bdev(struct bch_fs *c, struct bch_dev *ca,
 
 		if (model.nr)
 			strtomem_pad(m->device_model, model.data, '\0');
+
+		if (serial.nr)
+			strtomem_pad(m->device_serial, serial.data, '\0');
 	}
 
 	/* Commit: */

--- a/fs/bcachefs/sb/members.c
+++ b/fs/bcachefs/sb/members.c
@@ -291,6 +291,7 @@ void bch2_member_to_text(struct printbuf *out,
 
 	prt_printf(out, "Last device name:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Last device model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);
+	prt_printf(out, "Last device serial:\t%.*s\n", (int) sizeof(m->device_serial), m->device_serial);
 
 	if (m->flush_errors)
 		prt_printf(out, "Flush errors:\t%llu\n", le64_to_cpu(m->flush_errors));
@@ -314,6 +315,7 @@ static void bch2_member_to_text_short_sb(struct printbuf *out,
 
 	prt_printf(out, "Device:\t%.*s\n", (int) sizeof(m->device_name), m->device_name);
 	prt_printf(out, "Model:\t%.*s\n", (int) sizeof(m->device_model), m->device_model);
+	prt_printf(out, "Serial:\t%.*s\n", (int) sizeof(m->device_serial), m->device_serial);
 
 	prt_printf(out, "State:\t%s\n",
 		   BCH_MEMBER_STATE(m) < BCH_MEMBER_STATE_NR

--- a/fs/bcachefs/sb/members_format.h
+++ b/fs/bcachefs/sb/members_format.h
@@ -75,6 +75,7 @@ struct bch_member {
 	__u8			device_name[16] __nonstring;
 	__u8			device_model[64] __nonstring;
 	__le64			flush_errors;
+	__u8			device_serial[64] __nonstring;
 };
 
 /*


### PR DESCRIPTION
Add device_serial[64] field to bch_member, populated from /sys/block/{name}/device/serial at device attach time. This is useful for identifying physical hardware in multi-disk arrays.

The field is appended to the end of bch_member, so it is fully backwards-compatible via the members_v2 variable-size member format.

Co-authored by Claude, verified and tested by me.