### PR TITLE
bcachefs: fix linking error on i586

### DIFF
--- a/fs/bcachefs/data/io_misc.c
+++ b/fs/bcachefs/data/io_misc.c
@@ -68,7 +68,7 @@ int bch2_extent_fallocate(struct btree_trans *trans,
 	}
 
 	if (new_replicas)
-		sectors = res.r.sectors / new_replicas;
+		sectors = div_u64(res.r.sectors, new_replicas);
 
 	bch2_bkey_buf_reassemble(&old, k);
 


### PR DESCRIPTION
Building the kernel module for x86_32 yields an error since probably v6.17-1405-g37b736119d44 (bcachefs-tools v1.36.1-313-g719911d3):

```
...
/usr/bin/make -f /usr/src/linux-6.19.9-1/scripts/Makefile.modpost
   /usr/src/linux-6.19.9-1-obj/i386/default/scripts/mod/modpost -M -m -b -a \
      -o Module.symvers -n -T modules.order -i \
      /usr/src/linux-6.19.9-1-obj/i386/default/Module.symvers -e
ERROR: modpost: "__udivdi3" [src/fs/bcachefs/bcachefs.ko] undefined!
```