### PR TITLE
bcachefs: reconcile: detect and rewrite narrow EC stripes

### DIFF
--- a/fs/bcachefs/data/ec/create.c
+++ b/fs/bcachefs/data/ec/create.c
@@ -779,9 +779,9 @@ static unsigned pick_blocksize(struct bch_fs *c,
 }
 
 /* returns blocksize */
-static unsigned disk_label_ec_devs(struct bch_fs *c, unsigned disk_label,
-				   struct bch_devs_mask *devs,
-				   unsigned blocksize)
+unsigned disk_label_ec_devs(struct bch_fs *c, unsigned disk_label,
+			    struct bch_devs_mask *devs,
+			    unsigned blocksize)
 {
 	guard(rcu)();
 

--- a/fs/bcachefs/data/ec/create.h
+++ b/fs/bcachefs/data/ec/create.h
@@ -99,6 +99,8 @@ struct ec_stripe_head {
 
 void *bch2_writepoint_ec_buf(struct bch_fs *, struct write_point *);
 
+unsigned disk_label_ec_devs(struct bch_fs *, unsigned, struct bch_devs_mask *, unsigned);
+
 void bch2_ec_stripe_new_cancel(struct bch_fs *, struct ec_stripe_head *, int);
 void bch2_ec_bucket_cancel(struct bch_fs *, struct open_bucket *, int);
 

--- a/fs/bcachefs/data/reconcile/format.h
+++ b/fs/bcachefs/data/reconcile/format.h
@@ -156,6 +156,8 @@ enum bch_reconcile_opts {
 #define x(n)	BCH_RECONCILE_##n,
 	BCH_RECONCILE_OPTS()
 #undef x
+	/* Not an inode opt; standalone need_rb flag for narrow EC stripes */
+	BCH_RECONCILE_stripe_width,
 };
 
 #define BCH_RECONCILE_ACCOUNTING()		\

--- a/fs/bcachefs/data/reconcile/format.h
+++ b/fs/bcachefs/data/reconcile/format.h
@@ -90,7 +90,8 @@ struct bch_extent_rebalance_v1 {
 struct bch_extent_reconcile {
 #if defined(__LITTLE_ENDIAN_BITFIELD)
 	__u64	type:8,
-		unused:2,
+		unused:1,
+		need_restripe:1,
 		ptrs_moving:5,
 		hipri:1,
 		pending:1,
@@ -128,7 +129,8 @@ struct bch_extent_reconcile {
 		pending:1,
 		hipri:1,
 		ptrs_moving:5,
-		unused:2,
+		need_restripe:1,
+		unused:1,
 		type:8;
 #endif
 };
@@ -156,8 +158,6 @@ enum bch_reconcile_opts {
 #define x(n)	BCH_RECONCILE_##n,
 	BCH_RECONCILE_OPTS()
 #undef x
-	/* Not an inode opt; standalone need_rb flag for narrow EC stripes */
-	BCH_RECONCILE_stripe_width,
 };
 
 #define BCH_RECONCILE_ACCOUNTING()		\

--- a/fs/bcachefs/data/reconcile/trigger.c
+++ b/fs/bcachefs/data/reconcile/trigger.c
@@ -690,7 +690,8 @@ static int new_needs_rb_allowed(struct btree_trans *trans,
 
 	if (ctx == SET_NEEDS_RECONCILE_foreground) {
 		new_need_rb &= ~(BIT(BCH_RECONCILE_background_compression)|
-				 BIT(BCH_RECONCILE_background_target));
+				 BIT(BCH_RECONCILE_background_target)|
+				 BIT(BCH_RECONCILE_stripe_width));
 
 		/*
 		 * Foreground writes might end up degraded when a device is

--- a/fs/bcachefs/data/reconcile/trigger.c
+++ b/fs/bcachefs/data/reconcile/trigger.c
@@ -583,6 +583,7 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 	 * since an extent could have replicas in different stripes.
 	 */
 	if (ec && !unwritten && !(r.need_rb & BIT(BCH_RECONCILE_erasure_code))) {
+		/* Short-circuit: once flagged, the whole extent is rewritten */
 		for (unsigned i = 0; i < nr_ec_stripes && !r.need_restripe; i++) {
 			CLASS(btree_iter, s_iter)(trans, BTREE_ID_stripes,
 						 POS(0, ec_stripe_idxs[i]), 0);

--- a/fs/bcachefs/data/reconcile/trigger.c
+++ b/fs/bcachefs/data/reconcile/trigger.c
@@ -10,6 +10,8 @@
 
 #include "data/checksum.h"
 #include "data/compress.h"
+#include "data/ec/create.h"
+#include "data/ec/format.h"
 #include "data/extents.h"
 #include "data/reconcile/trigger.h"
 #include "data/reconcile/work.h"
@@ -481,6 +483,7 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 	bool incompressible = false, unwritten = false, ec = false;
 	unsigned durability = 0, durability_acct = 0, invalid = 0, min_durability = INT_MAX;
 	unsigned ec_redundancy = 0;
+	u64 ec_stripe_idx = 0;
 
 	const union bch_extent_entry *entry;
 	struct extent_ptr_decoded p;
@@ -534,6 +537,8 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 
 		if (p.has_ec && r.erasure_code)
 			ec_redundancy = max_t(unsigned, ec_redundancy, p.ec.redundancy);
+		if (p.has_ec && !ec)
+			ec_stripe_idx = p.ec.idx;
 		ec |= p.has_ec;
 
 		invalid += p.ptr.dev == BCH_SB_MEMBER_INVALID;
@@ -564,6 +569,40 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 
 	if (!unwritten && r.erasure_code != ec)
 		r.need_rb |= BIT(BCH_RECONCILE_erasure_code);
+
+	/*
+	 * Narrow EC stripe detection: if the extent is in an EC stripe
+	 * with fewer data blocks than the current target geometry allows,
+	 * flag it for reconcile to rewrite into a wider stripe.
+	 *
+	 * Only check when EC is present and desired (no erasure_code
+	 * mismatch), and skip unwritten extents.
+	 */
+	if (ec && !unwritten && !(r.need_rb & BIT(BCH_RECONCILE_erasure_code))) {
+		CLASS(btree_iter, s_iter)(trans, BTREE_ID_stripes,
+					 POS(0, ec_stripe_idx), 0);
+		struct bkey_s_c s_k =
+			bkey_try(bch2_btree_iter_peek_slot(&s_iter));
+
+		if (s_k.k->type == KEY_TYPE_stripe) {
+			const struct bch_stripe *s = bkey_s_c_to_stripe(s_k).v;
+			unsigned nr_data = s->nr_blocks - s->nr_redundant;
+
+			struct bch_devs_mask devs;
+			disk_label_ec_devs(c, s->disk_label, &devs,
+					   le16_to_cpu(s->sectors));
+			unsigned nr_devs = dev_mask_nr(&devs);
+
+			if (nr_devs >= s->nr_redundant + 2) {
+				unsigned target_nr_data =
+					min_t(unsigned, nr_devs,
+					      BCH_BKEY_PTRS_MAX) - s->nr_redundant;
+
+				if (nr_data < target_nr_data)
+					r.need_rb |= BIT(BCH_RECONCILE_stripe_width);
+			}
+		}
+	}
 
 	*need_update_invalid_devs =
 		min_t(int, durability_acct + invalid - r.data_replicas, invalid);

--- a/fs/bcachefs/data/reconcile/trigger.c
+++ b/fs/bcachefs/data/reconcile/trigger.c
@@ -128,6 +128,8 @@ void bch2_extent_reconcile_to_text(struct printbuf *out, struct bch_fs *c,
 	prt_str(out, "need_rb=");
 	prt_bitflags(out, bch2_reconcile_opts, r->need_rb);
 
+	if (r->need_restripe)
+		prt_str(out, " need_restripe");
 	if (r->hipri)
 		prt_str(out, " hipri");
 	if (r->pending)
@@ -450,7 +452,7 @@ static inline bool bkey_should_have_rb_opts(struct bkey_s_c k,
 		BCH_RECONCILE_OPTS()
 #undef x
 	}
-	return new.need_rb;
+	return new.need_rb || new.need_restripe;
 }
 
 static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c k,
@@ -483,7 +485,8 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 	bool incompressible = false, unwritten = false, ec = false;
 	unsigned durability = 0, durability_acct = 0, invalid = 0, min_durability = INT_MAX;
 	unsigned ec_redundancy = 0;
-	u64 ec_stripe_idx = 0;
+	unsigned nr_ec_stripes = 0;
+	u64 ec_stripe_idxs[BCH_BKEY_PTRS_MAX];
 
 	const union bch_extent_entry *entry;
 	struct extent_ptr_decoded p;
@@ -537,8 +540,8 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 
 		if (p.has_ec && r.erasure_code)
 			ec_redundancy = max_t(unsigned, ec_redundancy, p.ec.redundancy);
-		if (p.has_ec && !ec)
-			ec_stripe_idx = p.ec.idx;
+		if (p.has_ec)
+			ec_stripe_idxs[nr_ec_stripes++] = p.ec.idx;
 		ec |= p.has_ec;
 
 		invalid += p.ptr.dev == BCH_SB_MEMBER_INVALID;
@@ -576,30 +579,33 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 	 * flag it for reconcile to rewrite into a wider stripe.
 	 *
 	 * Only check when EC is present and desired (no erasure_code
-	 * mismatch), and skip unwritten extents.
+	 * mismatch), and skip unwritten extents. Checks all stripe_ptrs
+	 * since an extent could have replicas in different stripes.
 	 */
 	if (ec && !unwritten && !(r.need_rb & BIT(BCH_RECONCILE_erasure_code))) {
-		CLASS(btree_iter, s_iter)(trans, BTREE_ID_stripes,
-					 POS(0, ec_stripe_idx), 0);
-		struct bkey_s_c s_k =
-			bkey_try(bch2_btree_iter_peek_slot(&s_iter));
+		for (unsigned i = 0; i < nr_ec_stripes && !r.need_restripe; i++) {
+			CLASS(btree_iter, s_iter)(trans, BTREE_ID_stripes,
+						 POS(0, ec_stripe_idxs[i]), 0);
+			struct bkey_s_c s_k =
+				bkey_try(bch2_btree_iter_peek_slot(&s_iter));
 
-		if (s_k.k->type == KEY_TYPE_stripe) {
-			const struct bch_stripe *s = bkey_s_c_to_stripe(s_k).v;
-			unsigned nr_data = s->nr_blocks - s->nr_redundant;
+			if (s_k.k->type == KEY_TYPE_stripe) {
+				const struct bch_stripe *s = bkey_s_c_to_stripe(s_k).v;
+				unsigned nr_data = s->nr_blocks - s->nr_redundant;
 
-			struct bch_devs_mask devs;
-			disk_label_ec_devs(c, s->disk_label, &devs,
-					   le16_to_cpu(s->sectors));
-			unsigned nr_devs = dev_mask_nr(&devs);
+				struct bch_devs_mask devs;
+				disk_label_ec_devs(c, s->disk_label, &devs,
+						   le16_to_cpu(s->sectors));
+				unsigned nr_devs = dev_mask_nr(&devs);
 
-			if (nr_devs >= s->nr_redundant + 2) {
-				unsigned target_nr_data =
-					min_t(unsigned, nr_devs,
-					      BCH_BKEY_PTRS_MAX) - s->nr_redundant;
+				if (nr_devs >= s->nr_redundant + 2) {
+					unsigned target_nr_data =
+						min_t(unsigned, nr_devs,
+						      BCH_BKEY_PTRS_MAX) - s->nr_redundant;
 
-				if (nr_data < target_nr_data)
-					r.need_rb |= BIT(BCH_RECONCILE_stripe_width);
+					if (nr_data < target_nr_data)
+						r.need_restripe = 1;
+				}
 			}
 		}
 	}
@@ -729,8 +735,7 @@ static int new_needs_rb_allowed(struct btree_trans *trans,
 
 	if (ctx == SET_NEEDS_RECONCILE_foreground) {
 		new_need_rb &= ~(BIT(BCH_RECONCILE_background_compression)|
-				 BIT(BCH_RECONCILE_background_target)|
-				 BIT(BCH_RECONCILE_stripe_width));
+				 BIT(BCH_RECONCILE_background_target));
 
 		/*
 		 * Foreground writes might end up degraded when a device is

--- a/fs/bcachefs/data/reconcile/trigger.c
+++ b/fs/bcachefs/data/reconcile/trigger.c
@@ -604,8 +604,14 @@ static int bch2_bkey_needs_reconcile(struct btree_trans *trans, struct bkey_s_c 
 						min_t(unsigned, nr_devs,
 						      BCH_BKEY_PTRS_MAX) - s->nr_redundant;
 
-					if (nr_data < target_nr_data)
+					if (nr_data < target_nr_data) {
+						bch_info_ratelimited(c,
+							"reconcile: narrow stripe %llu (%u+%u, target %u+%u), queuing restripe",
+							ec_stripe_idxs[i],
+							nr_data, s->nr_redundant,
+							target_nr_data, s->nr_redundant);
 						r.need_restripe = 1;
+					}
 				}
 			}
 		}

--- a/fs/bcachefs/data/reconcile/trigger.h
+++ b/fs/bcachefs/data/reconcile/trigger.h
@@ -35,7 +35,7 @@ static inline struct bbpos rb_work_to_data_pos(struct bpos pos)
 
 static inline enum reconcile_work_id rb_work_id(const struct bch_extent_reconcile *r)
 {
-	if (!r || !r->need_rb)
+	if (!r || (!r->need_rb && !r->need_restripe))
 		return RECONCILE_WORK_none;
 	if (r->pending)
 		return RECONCILE_WORK_pending;
@@ -111,7 +111,7 @@ int __bch2_trigger_extent_reconcile(struct btree_trans *,
 
 static inline unsigned rb_needs_trigger(const struct bch_extent_reconcile *r)
 {
-	return r ? r->need_rb|r->ptrs_moving : 0;
+	return r ? r->need_rb|r->need_restripe|r->ptrs_moving : 0;
 }
 
 static inline int bch2_trigger_extent_reconcile(struct btree_trans *trans,

--- a/fs/bcachefs/data/reconcile/work.c
+++ b/fs/bcachefs/data/reconcile/work.c
@@ -745,6 +745,16 @@ static int do_reconcile_extent(struct moving_context *ctxt,
 				  work, &iter, 0,
 				  bkey_i_to_s_c(stack_k.k), stripe_retry));
 
+	{
+		const struct bch_extent_reconcile *r =
+			bch2_bkey_reconcile_opts(c, bkey_i_to_s_c(stack_k.k));
+		if (r && r->need_restripe)
+			bch_info_ratelimited(c,
+				"reconcile: restriping extent %llu:%llu",
+				stack_k.k->k.p.inode,
+				stack_k.k->k.p.offset);
+	}
+
 	event_add_trace(c, reconcile_data, stack_k.k->k.size, buf, ({
 		prt_newline(&buf);
 		bch2_bkey_val_to_text(&buf, c, bkey_i_to_s_c(stack_k.k));

--- a/fs/bcachefs/data/reconcile/work.c
+++ b/fs/bcachefs/data/reconcile/work.c
@@ -51,7 +51,6 @@ enum reconcile_phase_type {
 
 const char * const bch2_reconcile_opts[] = {
 	BCH_RECONCILE_OPTS()
-	[BCH_RECONCILE_stripe_width] = "stripe_width",
 	NULL
 };
 
@@ -416,7 +415,7 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 		}
 	}
 
-	if (r->need_rb & BIT(BCH_RECONCILE_stripe_width)) {
+	if (r->need_restripe) {
 		/*
 		 * Extent lives in a narrow EC stripe; drop the EC encoding
 		 * so data gets rewritten to new buckets and re-encoded into

--- a/fs/bcachefs/data/reconcile/work.c
+++ b/fs/bcachefs/data/reconcile/work.c
@@ -51,6 +51,7 @@ enum reconcile_phase_type {
 
 const char * const bch2_reconcile_opts[] = {
 	BCH_RECONCILE_OPTS()
+	[BCH_RECONCILE_stripe_width] = "stripe_width",
 	NULL
 };
 
@@ -412,6 +413,20 @@ static int reconcile_set_data_opts(struct btree_trans *trans,
 
 				ptr_bit <<= 1;
 			}
+		}
+	}
+
+	if (r->need_rb & BIT(BCH_RECONCILE_stripe_width)) {
+		/*
+		 * Extent lives in a narrow EC stripe; drop the EC encoding
+		 * so data gets rewritten to new buckets and re-encoded into
+		 * a (hopefully wider) stripe by the normal EC background path.
+		 */
+		unsigned ptr_bit = 1;
+		bkey_for_each_ptr_decode(k.k, ptrs, p, entry) {
+			if (p.has_ec)
+				data_opts->ptrs_kill_ec |= ptr_bit;
+			ptr_bit <<= 1;
 		}
 	}
 

--- a/fs/bcachefs/debug/sysfs.c
+++ b/fs/bcachefs/debug/sysfs.c
@@ -166,6 +166,7 @@ write_attribute(trigger_freelist_wakeup);
 write_attribute(trigger_recalc_capacity);
 write_attribute(trigger_reconcile_wakeup);
 write_attribute(trigger_reconcile_pending_wakeup);
+write_attribute(trigger_reconcile_restripe);
 write_attribute(trigger_delete_dead_snapshots);
 write_attribute(trigger_emergency_read_only);
 read_attribute(gc_gens_pos);
@@ -471,6 +472,9 @@ STORE(bch2_fs)
 	if (attr == &sysfs_trigger_reconcile_pending_wakeup)
 		bch2_reconcile_pending_wakeup(c);
 
+	if (attr == &sysfs_trigger_reconcile_restripe)
+		bch2_set_fs_needs_reconcile(c);
+
 	if (!enumerated_ref_tryget(&c->writes, BCH_WRITE_REF_sysfs))
 		return -EROFS;
 
@@ -642,6 +646,7 @@ struct attribute *bch2_fs_internal_files[] = {
 	&sysfs_trigger_recalc_capacity,
 	&sysfs_trigger_reconcile_wakeup,
 	&sysfs_trigger_reconcile_pending_wakeup,
+	&sysfs_trigger_reconcile_restripe,
 	&sysfs_trigger_delete_dead_snapshots,
 	&sysfs_trigger_emergency_read_only,
 


### PR DESCRIPTION
### Summary

- Add need_restripe flag to bch_extent_reconcile for extents in EC stripes narrower than current target geometry
- Detect narrow stripes during reconcile scan by looking up stripe width in BTREE_ID_stripes and comparing against disk_label_ec_devs() target
- Execution handler kills EC pointers so data gets rewritten and re-encoded into wider stripes
- sysfs trigger (trigger_reconcile_restripe) forces a scan to discover narrow stripes on demand

When the EC allocator fires may_shrink under pressure, it creates stripes narrower than the target (e.g. 2+2 instead of 6+2). These persist indefinitely. This series lets reconcile detect and rewrite them into full-width stripes through the normal move/EC background path.

Independent of #1118 (may_shrink metadata fix). That PR prevents corrupt narrow stripes from being created; this one cleans up correctly-formed narrow stripes after the fact.

###   Design notes

- need_restripe is a standalone 1-bit flag (repurposed from unused:2), not a need_rb bit. The need_rb field is 5 bits; a new enum value at position 6 would overflow silently.
- Bucket size filtering via disk_label_ec_devs() prevents flagging stripes that are correctly sized for their bucket-size class in mixed-device pools.
- Device count guard (nr_devs >= nr_redundant + 2) prevents flagging when wider stripes can't be formed.
- Rate-limited bch_info on detection for operator visibility in dmesg.
