### PR TITLE
bcachefs: six_lock: priority-aware wakeup for intent/write locks

### DIFF
--- a/fs/bcachefs/btree/write_buffer.c
+++ b/fs/bcachefs/btree/write_buffer.c
@@ -676,6 +676,7 @@ static int bch2_btree_write_buffer_journal_flush(struct journal *j,
 {
 	struct bch_fs *c = container_of(j, struct bch_fs, journal);
 	CLASS(btree_trans, trans)(c);
+	trans->locking_wait.priority = 1;
 	bool did_work = false;
 
 	return btree_write_buffer_flush_seq(trans, seq, &did_work, WB_FLUSH_journal_pin);
@@ -702,6 +703,7 @@ bool bch2_btree_write_buffer_flush_going_ro(struct bch_fs *c)
 		return false;
 
 	CLASS(btree_trans, trans)(c);
+	trans->locking_wait.priority = 1;
 	bool did_work = false;
 	btree_write_buffer_flush_seq(trans, journal_cur_seq(&c->journal), &did_work,
 				     WB_FLUSH_sync);

--- a/fs/bcachefs/btree/write_buffer.c
+++ b/fs/bcachefs/btree/write_buffer.c
@@ -805,6 +805,13 @@ static int bch2_btree_write_buffer_flush_thread(void *arg)
 		scoped_guard(memalloc_flags, PF_MEMALLOC_NOFS) {
 			guard(mutex)(&wb->flushing.lock);
 			CLASS(btree_trans, trans)(c);
+			/*
+			 * WB flush must win btree lock contention against
+			 * background workers: journal reclaim depends on WB
+			 * flush making progress, and a thundering herd of
+			 * reconcile/move workers can starve it.
+			 */
+			trans->locking_wait.priority = 1;
 			do {
 				bch2_trans_unlock_long(trans);
 				bch2_btree_write_buffer_flush_locked(trans, WB_FLUSH_thread);

--- a/fs/bcachefs/util/six.c
+++ b/fs/bcachefs/util/six.c
@@ -255,56 +255,93 @@ static inline void six_lock_prune_tombstones(struct six_lock *lock)
 		__six_lock_prune_tombstones(lock);
 }
 
+static inline void six_lock_wakeup_waiter(struct six_lock *lock,
+					  struct six_lock_wait_fifo *wf,
+					  struct six_lock_waiter *w, u16 iter)
+{
+	struct task_struct *task;
+
+	/*
+	 * Similar to percpu_rwsem_wake_function(), we need to guard
+	 * against the wakee noticing w->lock_acquired, returning, and
+	 * then exiting before we do the wakeup:
+	 */
+	task = get_task_struct(w->task);
+	fifo_entry(wf, iter) = NULL;
+	lock->wait_list_tombstones++;
+	/*
+	 * The release barrier here ensures the ordering of the fifo
+	 * entry removal before setting w->lock_acquired; @w is on the
+	 * stack of the thread doing the waiting and will be reused
+	 * after it sees w->lock_acquired with no other locking:
+	 * pairs with smp_load_acquire() in six_lock_slowpath()
+	 */
+	smp_store_release(&w->lock_acquired, true);
+	wake_up_process(task);
+	put_task_struct(task);
+}
+
 static void __six_lock_wakeup(struct six_lock *lock, enum six_lock_type lock_type)
 {
 	struct six_lock_waiter *w;
-	struct task_struct *task;
-	bool saw_one;
 	u16 iter;
 	int ret;
 again:
 	ret = 0;
-	saw_one = false;
 	raw_spin_lock(&lock->wait_lock);
 	struct six_lock_wait_fifo *wf = rcu_dereference_protected(lock->wait_fifo,
 						lockdep_is_held(&lock->wait_lock));
 
-	fifo_for_each_entry(w, wf, iter) {
-		if (!w)
-			continue;
-
-		if (w->lock_want != lock_type)
-			continue;
-
-		if (saw_one && lock_type != SIX_LOCK_read)
-			goto unlock;
-		saw_one = true;
-
-		ret = __do_six_trylock(lock, lock_type, w->task, false);
-		if (ret <= 0)
-			goto unlock;
-
+	if (lock_type != SIX_LOCK_read) {
 		/*
-		 * Similar to percpu_rwsem_wake_function(), we need to guard
-		 * against the wakee noticing w->lock_acquired, returning, and
-		 * then exiting before we do the wakeup:
+		 * For intent/write: find the highest-priority matching waiter.
+		 * Ties are broken by FIFO order (first match wins), so default
+		 * priority 0 preserves pure FIFO wakeup semantics.
 		 */
-		task = get_task_struct(w->task);
-		fifo_entry(wf, iter) = NULL;
-		lock->wait_list_tombstones++;
-		/*
-		 * The release barrier here ensures the ordering of the
-		 * __list_del before setting w->lock_acquired; @w is on the
-		 * stack of the thread doing the waiting and will be reused
-		 * after it sees w->lock_acquired with no other locking:
-		 * pairs with smp_load_acquire() in six_lock_slowpath()
-		 */
-		smp_store_release(&w->lock_acquired, true);
-		wake_up_process(task);
-		put_task_struct(task);
+		struct six_lock_waiter *best = NULL;
+		u16 best_iter = 0;
+		unsigned nr_matches = 0;
+
+		fifo_for_each_entry(w, wf, iter) {
+			if (!w || w->lock_want != lock_type)
+				continue;
+			nr_matches++;
+			if (!best || w->priority > best->priority) {
+				best = w;
+				best_iter = iter;
+			}
+		}
+
+		if (best) {
+			ret = __do_six_trylock(lock, lock_type, best->task, false);
+			if (ret > 0) {
+				six_lock_wakeup_waiter(lock, wf, best, best_iter);
+
+				if (nr_matches == 1)
+					six_clear_bitmask(lock, SIX_LOCK_WAITING_read << lock_type);
+			}
+		} else {
+			six_clear_bitmask(lock, SIX_LOCK_WAITING_read << lock_type);
+		}
+	} else {
+		bool saw_one = false;
+
+		fifo_for_each_entry(w, wf, iter) {
+			if (!w || w->lock_want != lock_type)
+				continue;
+
+			saw_one = true;
+
+			ret = __do_six_trylock(lock, lock_type, w->task, false);
+			if (ret <= 0)
+				goto unlock;
+
+			six_lock_wakeup_waiter(lock, wf, w, iter);
+		}
+
+		if (!saw_one)
+			six_clear_bitmask(lock, SIX_LOCK_WAITING_read << lock_type);
 	}
-
-	six_clear_bitmask(lock, SIX_LOCK_WAITING_read << lock_type);
 unlock:
 	six_lock_prune_tombstones(lock);
 	raw_spin_unlock(&lock->wait_lock);

--- a/fs/bcachefs/util/six.h
+++ b/fs/bcachefs/util/six.h
@@ -121,6 +121,21 @@
  *   Also, six_lock_waiter contains a timestamp, and waiters on a waitlist will
  *   have timestamps in strictly ascending order - this is so the timestamp can
  *   be used as a cursor for lock graph traverse.
+ *
+ * Wakeup priority:
+ *
+ *   For intent and write locks, the wakeup path selects the highest-priority
+ *   waiter from the waitlist rather than strictly the first (FIFO) entry.
+ *   When all waiters have the default priority (0), the first matching entry
+ *   wins -- identical to pure FIFO ordering.
+ *
+ *   This allows critical infrastructure threads (e.g. the write buffer flush
+ *   thread, whose progress is required for journal reclaim) to take locks
+ *   ahead of a large number of background workers, preventing priority
+ *   inversion under heavy concurrency.
+ *
+ *   Read lock wakeups are unaffected: all waiting readers are woken
+ *   unconditionally, since read locks do not conflict with each other.
  */
 
 #include <linux/lockdep.h>
@@ -140,6 +155,8 @@ struct six_lock_waiter {
 	enum six_lock_type	lock_want;
 	bool			lock_acquired;
 	u64			start_time;
+	/* 0 = default (FIFO order); higher values win in wakeup selection */
+	u8			priority;
 };
 
 /*


### PR DESCRIPTION
### Symptom

Under sustained concurrent load (reconcile + copygc + foreground IO with move_ios_in_flight=256), the system stalls hard: load average ~1100, ~233 tasks in D state, foreground IO frozen, no forward progress. Recovery requires a reboot.

### Root cause

FIFO starvation of the write buffer flush thread on btree node locks.

The wait queue on a contended btree node fills with background workers (reconcile, copygc, move). The WB flush thread joins the same FIFO and waits its turn behind hundreds of them. Because new background workers keep arriving, its position in the queue improves slowly or not at all relative to lock hold time.

This is not a deadlock. No task holds a lock it is itself waiting on. It is a queueing pathology: the WB flush thread is making no statistically meaningful progress through the FIFO under steady-state arrival from background workers.

### Why that wedges the system

WB flush progress is on the critical path for journal reclaim. Once journal reclaim stalls, `journal_res_get()` blocks, which blocks every foreground writer. The starvation of one thread on one queue is therefore amplified into a global IO stall.
In other words: the FIFO is locally fair but globally pathological, because not all waiters are equivalent. The WB flush thread is a system-wide dependency; the background workers are not.
Fix
Allow specific threads to opt into priority on the wait queue. The wakeup path for intent/write locks selects the highest-priority matching waiter; ties fall back to FIFO order. Default priority is 0, so any waiter that does not opt in sees identical behavior to the current FIFO.
Today only the WB flush thread opts in (priority 1), on all three entry points that allocate their own `btree_trans`:

- the flush worker thread
- the journal pin flush path
- the going-ro flush path

This is sufficient to break the starvation: the WB flush thread reliably wins the queue against a herd of background workers, journal reclaim drains, foreground IO unblocks.

### Scope and non-goals

This is queue-priority only. It does not address priority inversion when a low-priority thread holds a contended lock with a high-priority thread waiting; that would require priority inheritance. The pathology here is queue depth, not hold time (hold times for btree node locks under this workload are short and bounded), so queue priority is sufficient.

This is also not a general-purpose priority scheme. The priority space is effectively `{0, 1}` and there is exactly one boosted producer. If more boosted producers are added later, aging or a priority ceiling should be considered to prevent priority-0 starvation in the inverse direction.
