### PR TITLE
Don't define bdev_rot on Linux 7

### DIFF
--- a/fs/bcachefs/util/util.h
+++ b/fs/bcachefs/util/util.h
@@ -60,7 +60,7 @@ static inline struct bio_vec *bio_inline_vecs(struct bio *bio)
  * 7.1 introduced bdev_rot() and removed bdev_nonrot(). Shim bdev_rot for
  * older kernels and userspace so call sites can always use bdev_rot.
  */
-#if !defined(__KERNEL__) || LINUX_VERSION_CODE < KERNEL_VERSION(7,1,0)
+#if !defined(__KERNEL__) || LINUX_VERSION_CODE < KERNEL_VERSION(7,0,0)
 static inline bool bdev_rot(struct block_device *bdev)
 {
 	return !bdev_nonrot(bdev);


### PR DESCRIPTION
While bdev_nonrot is removed in Linux 7.1, bdev_rot should only be shimmed on Linux < 7 (it was introduced in v7.0-rc1).
Fixes non-DKMS builds of bcachefs.