### PR TITLE
bcachefs: restore rw state after failed device remove

### DIFF
--- a/fs/bcachefs/init/dev.c
+++ b/fs/bcachefs/init/dev.c
@@ -883,10 +883,11 @@ int bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca, int flags,
 		    struct printbuf *err)
 {
 	unsigned dev_idx = ca->dev_idx, data;
+	bool was_rw = ca->mi.state == BCH_MEMBER_STATE_rw;
 	bool fast_device_removal = (c->sb.compat & BIT_ULL(BCH_COMPAT_no_stale_ptrs)) &&
 		!bch2_request_incompat_feature(c,
 					bcachefs_metadata_version_fast_device_removal);
-	int ret;
+	int ret, ret2;
 
 	guard(rwsem_write)(&c->state_lock);
 
@@ -1016,6 +1017,16 @@ int bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca, int flags,
 
 	return 0;
 err:
+	if (test_bit(BCH_FS_rw, &c->flags) &&
+	    was_rw &&
+	    ca->mi.state == BCH_MEMBER_STATE_evacuating &&
+	    !enumerated_ref_is_zero(&ca->io_ref[READ])) {
+		prt_str(err, "Remove failed, restoring device state to rw\n");
+		ret2 = __bch2_dev_set_state(c, ca, BCH_MEMBER_STATE_rw, flags, err);
+		if (ret2)
+			prt_printf(err, "Error restoring device state: %s\n", bch2_err_str(ret2));
+	}
+
 	if (test_bit(BCH_FS_rw, &c->flags) &&
 	    ca->mi.state == BCH_MEMBER_STATE_rw &&
 	    !enumerated_ref_is_zero(&ca->io_ref[READ]))


### PR DESCRIPTION
## Superseded / Correct Target

This closed kernel-tree PR is superseded by the correct-target bcachefs-tools PR `koverstreet/bcachefs-tools#596`. The successor carries the same small failed-remove state cleanup against the current `bcachefs-tools/testing` split tree as a Komzpa-authored patch, so this PR should be treated only as historical provenance for the earlier wrong-target attempt.

Active artifact: https://github.com/koverstreet/bcachefs-tools/pull/596

---

## Summary

`bch2_dev_remove()` temporarily switches a member to `evacuating` before it tries to drop the member's data. If an early failure occurs before `__bch2_dev_offline()` - for example because removing the member would lose data - the error path currently leaves the still-present member in the temporary `evacuating` state.

That makes a failed remove attempt sticky: users have to manually run `bcachefs device set-state rw` to put the member back into normal service.

Record whether the member was `rw` before the remove attempt and, on the online early error path, restore it to `rw` before returning the original error.

This fixes only the state leak from the failed remove attempt; it does not change the data/metadata migration decision that caused `remove` to fail.

Fixes: https://github.com/koverstreet/bcachefs/issues/1140
Related ktest coverage: https://github.com/koverstreet/ktest/pull/53

## Validation

- `git diff --check`
- `git diff | ./scripts/checkpatch.pl --strict -`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/bcachefs.o`
- ktest `failed_device_remove_restores_rw` passed in QEMU on this branch
  - remove failed as expected with `cannot drop device without degrading/losing data`
  - device state returned to `[rw]`
  - fsck completed; `TEST SUCCESS`

The HOSTCFLAGS override was needed locally because host-tool `tools/bpf/resolve_btfids/libbpf` fails with `-Werror=discarded-qualifiers` on this machine before reaching bcachefs objects. With that override, `fs/bcachefs/init/dev.o` and `fs/bcachefs/bcachefs.o` built successfully.

Stack ledger: koverstreet/bcachefs#1145

