### PR TITLE
bcachefs: rewrite btree nodes before dropping device metadata ptrs

### DIFF
--- a/fs/bcachefs/data/migrate.c
+++ b/fs/bcachefs/data/migrate.c
@@ -7,6 +7,7 @@
 
 #include "alloc/backpointers.h"
 #include "alloc/buckets.h"
+#include "alloc/disk_groups.h"
 #include "alloc/replicas.h"
 
 #include "btree/bkey_buf.h"
@@ -89,6 +90,57 @@ static int drop_btree_ptrs(struct btree_trans *trans, struct btree_iter *iter,
 	return bch2_btree_node_update_key(trans, iter, b, n, 0, false);
 }
 
+static unsigned int btree_ptr_rewrite_target(struct bch_fs *c)
+{
+	if (c->opts.metadata_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.metadata_target))
+		return c->opts.metadata_target;
+
+	if (c->opts.foreground_target &&
+	    bch2_target_accepts_data(c, BCH_DATA_btree, c->opts.foreground_target))
+		return c->opts.foreground_target;
+
+	return 0;
+}
+
+static int drop_or_rewrite_btree_ptrs(struct btree_trans *trans,
+				      struct btree_iter *iter,
+				      struct btree *b, unsigned int dev_idx,
+				      unsigned int flags, struct printbuf *err)
+{
+	/*
+	 * If dropping this ptr would under-replicate metadata, rewrite the node
+	 * first so removal can make forward progress without degrading it.
+	 */
+	struct printbuf drop_err = PRINTBUF;
+	int ret = drop_btree_ptrs(trans, iter, b, dev_idx, flags, &drop_err);
+	bool drop_would_degrade = bch2_err_matches(ret, BCH_ERR_remove_would_lose_data);
+
+	if (drop_would_degrade) {
+		ret = bch2_btree_node_rewrite_pos(trans, iter->btree_id,
+						  b->c.level + 1, b->key.k.p,
+						  btree_ptr_rewrite_target(trans->c),
+						  BCH_TRANS_COMMIT_no_enospc, 0);
+	}
+
+	if (bch2_err_matches(ret, BCH_ERR_transaction_restart))
+		goto out;
+
+	if (ret && drop_would_degrade) {
+		prt_printf(err,
+			   "cannot drop device metadata ptr without degrading metadata; "
+			   "btree node rewrite failed: %s\n  ",
+			   bch2_err_str(ret));
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	} else if (ret) {
+		prt_str(err, bch2_printbuf_str(&drop_err));
+	}
+out:
+	printbuf_exit(&drop_err);
+
+	return ret;
+}
+
 static int bch2_dev_usrdata_drop_key(struct btree_trans *trans,
 				     struct btree_iter *iter,
 				     struct bkey_s_c k,
@@ -122,7 +174,7 @@ static int bch2_dev_btree_drop_key(struct btree_trans *trans,
 	if (ret)
 		return ret == -BCH_ERR_backpointer_to_overwritten_btree_node ? 0 : ret;
 
-	return drop_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
+	return drop_or_rewrite_btree_ptrs(trans, &iter, b, dev_idx, flags, err);
 }
 
 static int bch2_dev_usrdata_drop(struct bch_fs *c,
@@ -161,11 +213,15 @@ static int dev_metadata_drop_one(struct btree_trans *trans,
 				 unsigned flags, struct printbuf *err)
 {
 	struct btree *b = errptr_try(bch2_btree_iter_peek_node(iter));
+	int ret;
+
 	if (!b)
 		return 1;
 
 	try(bch2_progress_update_iter(trans, progress, iter));
-	try(drop_btree_ptrs(trans, iter, b, dev_idx, flags, err));
+
+	ret = drop_or_rewrite_btree_ptrs(trans, iter, b, dev_idx, flags, err);
+	try(ret);
 	return 0;
 }
 
@@ -267,11 +323,14 @@ int bch2_dev_data_drop_by_backpointers(struct bch_fs *c, struct bch_dev *ca,
 		try(backpointer_scan_for_each(trans, iter, BTREE_ID_backpointers,
 					      POS(dev_idx, 0), POS(dev_idx, U64_MAX),
 						  &last_flushed, &progress, bp, ({
-			wb_maybe_flush_inc(&last_flushed);
-			CLASS(disk_reservation, res)(c);
-			data_drop_bp(trans, dev_idx, bp, &last_flushed, flags, err) ?:
-			bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
-		})));
+				wb_maybe_flush_inc(&last_flushed);
+				CLASS(disk_reservation, res)(c);
+				data_drop_bp(trans, dev_idx, bp, &last_flushed, flags, err) ?:
+				bch2_trans_commit(trans, &res.r, NULL, BCH_TRANS_COMMIT_no_enospc);
+			})));
+
+		bch2_trans_unlock_long(trans);
+		bch2_btree_interior_updates_flush(c);
 
 		if (!dev_has_data(c, ca))
 			return 0;


### PR DESCRIPTION
## Superseded / Correct Target

This closed kernel-tree PR is superseded by the correct-target bcachefs-tools device-remove work. The active successor is `koverstreet/bcachefs-tools#601`, which replaces the slower intermediate `koverstreet/bcachefs-tools#599` and keeps this Komzpa-authored btree-metadata rewrite idea in the current `bcachefs-tools/testing` split tree. Companion coverage is `koverstreet/ktest#55`.

Active artifacts:

- https://github.com/koverstreet/bcachefs-tools/pull/601
- https://github.com/koverstreet/ktest/pull/55

---

## Summary

`device remove` can encounter btree-node metadata that is only stored on the device being removed. Directly dropping that device pointer from the btree ptr would under-replicate metadata, so the old path reported `remove_would_lose_data`/`-EBUSY` and left `BCH_DATA_btree` buckets behind.

Rewrite the btree node first when dropping the device ptr would under-replicate metadata, then let the old node be freed. The helper is used from both removal paths:

- fast removal through backpointers (`bch2_dev_data_drop_by_backpointers()` -> `bch2_dev_btree_drop_key()`)
- the slower direct metadata scan (`bch2_dev_metadata_drop()`)

When `metadata_target` points at the device being removed, choose a live btree allocation target instead of asking allocation to write replacement metadata back to the evacuating device. Also flush btree interior updates before checking whether the device still has data, because btree-node rewrites may otherwise not be reflected in usage/accounting yet.

This intentionally keeps the mandatory drain in the remove path rather than copygc. Copygc is a best-effort bucket mover; `device remove` is the finalizer that must either remove/durable-rewrite remaining metadata or return a concrete blocked reason.

Related field report: koverstreet/bcachefs#1140
Related ktest coverage: https://github.com/koverstreet/ktest/pull/53

## Evidence

On a live pool with `metadata_replicas=2`, `device evacuate` returned `Done`, but `device remove` still failed with:

```text
Remove failed: still has data
  btree: 150 buckets
```

Debugfs showed remaining btree-node references in trees such as `accounting`, `alloc`, and `bucket_gens`, while user data on the device was already gone.

A synthetic ktest reproducer also failed before this fix: with `metadata_target=ssd`, `foreground_target=hdd`, and many small files, removing the SSD member failed with `cannot drop device without degrading/losing data` for `btree_ptr_v2` keys.

## Testing

- `git diff --check`
- `git diff | scripts/checkpatch.pl --strict --no-tree -`
- ktest `device_remove_rewrites_metadata` passed in QEMU against this branch
  - creates 1 GiB SSD + 16 GiB HDD filesystem with `metadata_target=ssd`
  - populates small-file metadata on the SSD
  - removes the SSD device
  - runs offline fsck with only the HDD device
- Earlier direct `make ... fs/bcachefs/data/migrate.o` compile was covered by the ktest kernel build; root-tree `make` without the ktest output dir has no `.config` in this checkout.

Stack ledger: koverstreet/bcachefs#1145

