### PR TITLE
bcachefs: trace allocator copygc progress decisions

### DIFF
--- a/fs/bcachefs/alloc/foreground.c
+++ b/fs/bcachefs/alloc/foreground.c
@@ -287,10 +287,12 @@ static struct open_bucket *__try_alloc_bucket(struct bch_fs *c,
 		if (req->cl) {
 			closure_wait(&c->allocator.open_buckets_wait, req->cl);
 			return ERR_PTR(alloc_trace_add(req, U8_MAX,
-					bch_err_throw(c, open_bucket_alloc_blocked), 0));
+					bch_err_throw(c, open_bucket_alloc_blocked),
+					0, 0, false));
 		} else {
 			return ERR_PTR(alloc_trace_add(req, U8_MAX,
-					bch_err_throw(c, open_buckets_empty), 0));
+					bch_err_throw(c, open_buckets_empty),
+					0, 0, false));
 		}
 	}
 
@@ -620,6 +622,7 @@ struct open_bucket *bch2_bucket_alloc_trans(struct btree_trans *trans,
 	struct open_bucket *ob = NULL;
 	bool freespace = READ_ONCE(ca->mi.freespace_initialized);
 	bool waiting = false;
+	bool copygc_can_make_progress = false;
 
 	req->btree_bitmap = req->data_type == BCH_DATA_btree;
 	memset(&req->counters, 0, sizeof(req->counters));
@@ -644,6 +647,7 @@ again:
 			goto alloc;
 
 		if (bch2_copygc_can_make_progress(ca)) {
+			copygc_can_make_progress = true;
 			req->copygc_can_make_progress = true;
 			bch2_copygc_wakeup(c);
 		}
@@ -709,7 +713,8 @@ err:
 		event_inc_trace(c, bucket_alloc_fail, buf,
 			bucket_alloc_to_text(&buf, c, req, ob));
 
-	alloc_trace_add(req, ca->dev_idx, ret, wake_counter_snapshot);
+	alloc_trace_add(req, ca->dev_idx, ret, wake_counter_snapshot,
+			avail, copygc_can_make_progress);
 
 	return ob;
 }
@@ -901,7 +906,7 @@ int bch2_bucket_alloc_set_trans(struct btree_trans *trans,
 	}
 
 	return ret ?: alloc_trace_add(req, BCH_SB_MEMBER_INVALID,
-			bch_err_throw(c, insufficient_devices), 0);
+			bch_err_throw(c, insufficient_devices), 0, 0, false);
 }
 
 /* Allocate from stripes: */
@@ -1765,7 +1770,7 @@ static inline bool dev_may_alloc(struct bch_fs *c, struct bch_dev *ca, struct al
 }
 
 static void alloc_trace_to_text(struct printbuf *out, struct bch_fs *c,
-			        struct alloc_request *req)
+				struct alloc_request *req)
 {
 	if (!req->trace.nr)
 		return;
@@ -1787,6 +1792,9 @@ static void alloc_trace_to_text(struct printbuf *out, struct bch_fs *c,
 				prt_str(out, " retry_set");
 			if (e->have_cl)
 				prt_str(out, " cl");
+			prt_printf(out, " free %llu copygc_progress %u",
+				   e->free_buckets,
+				   e->copygc_can_make_progress);
 			prt_printf(out, " -> %s\n",
 				   e->err ? bch2_err_str(e->err) : "ok");
 		}

--- a/fs/bcachefs/alloc/foreground.h
+++ b/fs/bcachefs/alloc/foreground.h
@@ -32,9 +32,11 @@ typedef struct {
 	bool	will_retry_all_devices:1;
 	bool	will_retry_target_devices:1;
 	bool	will_retry_set_devices:1;
+	bool	copygc_can_make_progress:1;
 	bool	have_cl:1;
 	s16	err;
 	u32	wake_counter_snapshot;
+	u64	free_buckets;
 } alloc_trace_entry;
 
 struct alloc_request {
@@ -105,7 +107,9 @@ struct alloc_request {
  */
 static inline int alloc_trace_add(struct alloc_request *req,
 				  u8 dev, int err,
-				  u32 wake_counter_snapshot)
+				  u32 wake_counter_snapshot,
+				  u64 free_buckets,
+				  bool copygc_can_make_progress)
 {
 	if (darray_push(&req->trace, ((alloc_trace_entry) {
 		.dev				= dev,
@@ -113,9 +117,11 @@ static inline int alloc_trace_add(struct alloc_request *req,
 		.will_retry_all_devices		= req->will_retry_all_devices,
 		.will_retry_target_devices	= req->will_retry_target_devices,
 		.will_retry_set_devices		= req->will_retry_set_devices,
+		.copygc_can_make_progress	= copygc_can_make_progress,
 		.have_cl			= req->cl != NULL,
 		.err				= err,
 		.wake_counter_snapshot		= wake_counter_snapshot,
+		.free_buckets			= free_buckets,
 	    })))
 		req->trace_alloc_failed = true;
 


### PR DESCRIPTION
## Summary

This extends the existing allocator attempt trace that is printed from allocator-stuck diagnostics with two extra pieces of per-attempt state:

- the free bucket count observed for the attempted device
- whether `bch2_copygc_can_make_progress()` was true for that device

The goal is to make target/copygc stalls diagnosable from the next stuck dump: if a request keeps sleeping because copygc is believed to be able to free space, the dump will now show the attempted device, retry flags, observed free buckets, and the copygc-progress predicate together.

## Motivation

A target/full-cache style allocator stall is otherwise hard to classify after the fact. In particular, when a preferred target is exhausted but fallback devices exist, we need to distinguish:

- soft-target fallback was not reached
- fallback was reached but no eligible device could satisfy the request
- the allocator slept because copygc progress was considered possible, even though no useful free buckets appeared

This patch is diagnostic only; it does not change allocation, retry, copygc, or durability semantics.

## Related test

Regression coverage for the soft foreground-target fallback case is proposed in koverstreet/ktest#53:

- https://github.com/koverstreet/ktest/pull/53

That test writes 1.5 GiB with `foreground_target=ssd` on a filesystem with a 1 GiB SSD tier and a 16 GiB HDD tier, and verifies the write completes instead of waiting forever on SSD/copygc progress.

## Validation

- `git diff --check`
- `git diff | scripts/checkpatch.pl --strict --no-tree -`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/alloc/foreground.o`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/bcachefs.o`
- ktest `foreground_target_full_fallback` passed in QEMU on this branch via koverstreet/ktest#53

Stack ledger: koverstreet/bcachefs#1145
