### PR TITLE
bcachefs: handle missing data update keys in debug text

### DIFF
--- a/fs/bcachefs/data/read.c
+++ b/fs/bcachefs/data/read.c
@@ -423,10 +423,20 @@ void bch2_promote_op_to_text(struct printbuf *out,
 			     struct bch_fs *c,
 			     struct promote_op *op)
 {
+	if (!op->write.op.c || !op->write.k.k) {
+		prt_printf(out, "(uninitialized data update)\n");
+		return;
+	}
+
 	if (!op->write.read_done) {
 		prt_printf(out, "parent read: %px\n", op->write.rbio.parent);
-		guard(printbuf_indent)(out);
-		bch2_read_bio_to_text(out, c, op->write.rbio.parent);
+		if (op->write.rbio.parent) {
+			guard(printbuf_indent)(out);
+			bch2_read_bio_to_text(out, c, op->write.rbio.parent);
+		} else {
+			guard(printbuf_indent)(out);
+			prt_printf(out, "(uninitialized)\n");
+		}
 	}
 
 	bch2_data_update_to_text(out, &op->write);

--- a/fs/bcachefs/data/update.c
+++ b/fs/bcachefs/data/update.c
@@ -918,11 +918,19 @@ void bch2_data_update_opts_to_text(struct printbuf *out, struct bch_fs *c,
 
 void bch2_data_update_to_text(struct printbuf *out, struct data_update *m)
 {
+	if (!m->op.c) {
+		prt_printf(out, "(uninitialized data update)\n");
+		return;
+	}
+
 	bch2_data_update_opts_to_text(out, m->op.c, &m->op.opts, &m->opts);
 	prt_newline(out);
 
 	prt_str(out, "old key:\t");
-	bch2_bkey_val_to_text(out, m->op.c, bkey_i_to_s_c(m->k.k));
+	if (m->k.k)
+		bch2_bkey_val_to_text(out, m->op.c, bkey_i_to_s_c(m->k.k));
+	else
+		prt_str(out, "(uninitialized)");
 	prt_newline(out);
 
 	prt_printf(out, "write: ");
@@ -931,7 +939,15 @@ void bch2_data_update_to_text(struct printbuf *out, struct data_update *m)
 
 void bch2_data_update_inflight_to_text(struct printbuf *out, struct data_update *m)
 {
-	bch2_bkey_val_to_text(out, m->op.c, bkey_i_to_s_c(m->k.k));
+	if (!m->op.c) {
+		prt_printf(out, "(uninitialized data update)\n");
+		return;
+	}
+
+	if (m->k.k)
+		bch2_bkey_val_to_text(out, m->op.c, bkey_i_to_s_c(m->k.k));
+	else
+		prt_str(out, "(uninitialized)");
 	prt_newline(out);
 	guard(printbuf_indent)(out);
 	bch2_data_update_opts_to_text(out, m->op.c, &m->op.opts, &m->opts);

--- a/fs/bcachefs/data/write.c
+++ b/fs/bcachefs/data/write.c
@@ -2585,7 +2585,10 @@ void bch2_write_op_to_text(struct printbuf *out, struct bch_write_op *op)
 		prt_newline(out);
 
 		prt_str(out, "old key:\t");
-		bch2_bkey_val_to_text(out, u->op.c, bkey_i_to_s_c(u->k.k));
+		if (u->k.k)
+			bch2_bkey_val_to_text(out, u->op.c, bkey_i_to_s_c(u->k.k));
+		else
+			prt_str(out, "(uninitialized)");
 		prt_newline(out);
 	}
 }


### PR DESCRIPTION
## Summary

`async_objs/promote` can expose a promote operation before its embedded `data_update` has finished initialization, or while an initialization failure is being unwound. In those windows the old key buffer, write op, or parent read pointer may still be missing.

Make the promote/data-update debug text paths tolerate that partial state instead of passing a missing key through `bkey_i_to_s_c()` or dereferencing an uninitialized parent read pointer. The related data-update inflight and write-op debug printers get the same old-key guard so async object dumps stay best-effort diagnostics.

Closes: koverstreet/bcachefs#1122

## Validation

- `git diff --check origin/master..HEAD`
- `scripts/checkpatch.pl --strict --no-tree -g HEAD`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/data/read.o fs/bcachefs/data/update.o fs/bcachefs/data/write.o`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/bcachefs.o`
- `codex review` on the code diff found no obvious regression after the partial-initialization guards were added

Stack ledger: koverstreet/bcachefs#1145
