### PR TITLE
bcachefs: clamp printbuf insert position before padding

### DIFF
--- a/fs/bcachefs/util/printbuf.c
+++ b/fs/bcachefs/util/printbuf.c
@@ -87,6 +87,8 @@ static void printbuf_advance_pos(struct printbuf *out, unsigned len)
 
 static void printbuf_insert_spaces(struct printbuf *out, unsigned pos, unsigned nr)
 {
+	pos = min(pos, out->pos);
+
 	unsigned move = out->pos - pos;
 
 	bch2_printbuf_make_room(out, nr);


### PR DESCRIPTION
## Summary
- Clamp stale printbuf insert positions before computing the move length for padding.
- Prevent `printbuf_insert_spaces()` from underflowing when tabstop/bookkeeping state points past the truncated write position after overflow/allocation failure.
- Closes koverstreet/bcachefs#1127.

## Validation
- `git diff --check origin/master..HEAD`
- `scripts/checkpatch.pl --strict --no-tree -g HEAD`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/util/printbuf.o fs/bcachefs/journal/reclaim.o`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/bcachefs/bcachefs.o`
- `codex review` on the same code diff before the branch-head refresh
- Included in refreshed aggregate koverstreet/bcachefs#1145 on base `ca944a61e079450f82be88c91e349638c75cf4b6`; aggregate `git diff --check`, aggregate checkpatch, and QEMU stack lanes passed on kernel `6.17.0-ktest-02013-gf1629081027b`

Stack ledger: koverstreet/bcachefs#1145
