### PR TITLE
bcachefs: refresh vfs device after member removal

### DIFF
--- a/fs/bcachefs/init/dev.c
+++ b/fs/bcachefs/init/dev.c
@@ -879,6 +879,28 @@ int bch2_dev_set_state(struct bch_fs *c, struct bch_dev *ca,
 
 /* Device add/removal: */
 
+static void bch2_dev_remove_update_vfs_sb(struct bch_fs *c, struct bch_dev *ca)
+{
+	struct super_block *sb = c->vfs_sb;
+	struct block_device *old_bdev = ca->disk_sb.bdev;
+
+	if (!sb || !old_bdev || sb->s_bdev != old_bdev)
+		return;
+
+	scoped_guard(rcu) {
+		for_each_online_member_rcu(c, ca2) {
+			struct block_device *bdev = ca2->disk_sb.bdev;
+
+			if (ca2 == ca || !bdev)
+				continue;
+
+			super_set_bdev(sb, bdev);
+			c->dev		= bdev->bd_dev;
+			return;
+		}
+	}
+}
+
 int bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca, int flags,
 		    struct printbuf *err)
 {
@@ -947,6 +969,7 @@ int bch2_dev_remove(struct bch_fs *c, struct bch_dev *ca, int flags,
 	 * Disallow reads before we remove alloc info, otherwise we'll get
 	 * spurious stale pointer errors:
 	 */
+	bch2_dev_remove_update_vfs_sb(c, ca);
 	__bch2_dev_offline(c, ca);
 
 	ret = bch2_dev_remove_alloc(c, ca);

--- a/fs/super.c
+++ b/fs/super.c
@@ -1651,6 +1651,15 @@ int setup_bdev_super(struct super_block *sb, int sb_flags,
 }
 EXPORT_SYMBOL_GPL(setup_bdev_super);
 
+void super_set_bdev(struct super_block *sb, struct block_device *bdev)
+{
+	spin_lock(&sb_lock);
+	sb->s_bdev = bdev;
+	sb->s_dev = bdev->bd_dev;
+	spin_unlock(&sb_lock);
+}
+EXPORT_SYMBOL_GPL(super_set_bdev);
+
 /**
  * get_tree_bdev_flags - Get a superblock based on a single block device
  * @fc: The filesystem context holding the parameters

--- a/include/linux/fs.h
+++ b/include/linux/fs.h
@@ -2777,6 +2777,7 @@ int thaw_super(struct super_block *super, enum freeze_holder who,
 extern __printf(2, 3)
 int super_setup_bdi_name(struct super_block *sb, char *fmt, ...);
 extern int super_setup_bdi(struct super_block *sb);
+void super_set_bdev(struct super_block *sb, struct block_device *bdev);
 
 static inline void super_set_uuid(struct super_block *sb, const u8 *uuid, unsigned len)
 {


### PR DESCRIPTION
## Summary
- Add a small VFS helper for switching a superblock representative block device under the VFS superblock lock.
- Move bcachefs' VFS representative device to another online member before freeing the removed member's disk superblock.
- Keep `c->dev` in sync so quota/stat lookup paths continue to resolve the mounted filesystem after removing the first member.
- Closes koverstreet/bcachefs#1106.

## Validation
- `git diff --check origin/master..HEAD`
- `scripts/checkpatch.pl --strict --no-tree -g HEAD`
- `make HOSTCFLAGS='-Wno-error=discarded-qualifiers' CONFIG_BCACHEFS_FS=m -j$(nproc) fs/super.o fs/bcachefs/init/dev.o fs/bcachefs/bcachefs.o`
- `codex review` on the same code diff before the branch-head refresh
- QEMU ktest `prjquota_after_primary_device_remove` passed in refreshed aggregate koverstreet/bcachefs#1145 on base `ca944a61e079450f82be88c91e349638c75cf4b6`, aggregate head `f1629081027bed0a5ea3ac8dc129d1771f1397f1`, kernel `6.17.0-ktest-02013-gf1629081027b`

Stack ledger: koverstreet/bcachefs#1145
