### PR TITLE
bcachefs: report block size for empty directories

### DIFF
--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -1178,6 +1178,8 @@ static int bch2_getattr(struct mnt_idmap *idmap,
 	stat->gid	= vfsgid_into_kgid(vfsgid);
 	stat->rdev	= inode->v.i_rdev;
 	stat->size	= i_size_read(&inode->v);
+	if (!stat->size && S_ISDIR(inode->v.i_mode))
+		stat->size = block_bytes(c);
 	stat->atime	= inode_get_atime(&inode->v);
 	stat->mtime	= inode_get_mtime(&inode->v);
 	stat->ctime	= inode_get_ctime(&inode->v);


### PR DESCRIPTION
bcachefs keeps directory i_size at zero on disk and fsck enforces that invariant, but getattr currently exposes that zero directly through stat(2). This makes both the root directory and newly created child directories report st_size=0, which is unusual compared with common filesystems and trips userspace that treats zero-sized directories as invalid.

Keep the on-disk invariant unchanged and synthesize the filesystem block size from getattr when a directory has no recorded size.

Validation:
- git diff --check
- git diff | scripts/checkpatch.pl --strict --no-tree -
- codex review --base origin/master --title 'bcachefs: report block size for empty directories'
- QEMU ktest before the fix: temporary repro reported root and child directory size 0
- QEMU ktest after the fix: tests/fs/bcachefs/single_device.ktest directory_stat_size_nonzero reported root and child directory size 4096 and TEST SUCCESS

Fixes koverstreet/bcachefs#1130

Related test coverage: koverstreet/ktest#53