### PR TITLE
bcachefs: initialize sectors_available_lock as a spinlock

### DIFF
--- a/fs/bcachefs/alloc/background.c
+++ b/fs/bcachefs/alloc/background.c
@@ -1712,7 +1712,7 @@ void bch2_fs_capacity_exit(struct bch_fs *c)
 
 int bch2_fs_capacity_init(struct bch_fs *c)
 {
-	mutex_init(&c->capacity.sectors_available_lock);
+	spin_lock_init(&c->capacity.sectors_available_lock);
 	seqcount_init(&c->capacity.usage_lock);
 
 	try(percpu_init_rwsem(&c->capacity.mark_lock));

--- a/fs/bcachefs/alloc/buckets.c
+++ b/fs/bcachefs/alloc/buckets.c
@@ -1174,7 +1174,7 @@ static int disk_reservation_recalc_sectors_available(struct bch_fs *c,
 			struct disk_reservation *res,
 			u64 sectors, enum bch_reservation_flags flags)
 {
-	guard(mutex)(&c->capacity.sectors_available_lock);
+	guard(spinlock)(&c->capacity.sectors_available_lock);
 
 	percpu_u64_set(&c->capacity.pcpu->sectors_available, 0);
 	u64 sectors_available = avail_factor(__bch2_fs_usage_read_short(c).free);
@@ -1198,23 +1198,18 @@ static int disk_reservation_recalc_sectors_available(struct bch_fs *c,
 int __bch2_disk_reservation_add(struct bch_fs *c, struct disk_reservation *res,
 				u64 sectors, enum bch_reservation_flags flags)
 {
-	struct bch_fs_capacity_pcpu *pcpu;
-	u64 old, get;
-
-	guard(percpu_read)(&c->capacity.mark_lock);
-	preempt_disable();
-	pcpu = this_cpu_ptr(c->capacity.pcpu);
+	guard(preempt)();
+	struct bch_fs_capacity_pcpu *pcpu = this_cpu_ptr(c->capacity.pcpu);
 
 	if (unlikely(sectors > pcpu->sectors_available)) {
-		old = atomic64_read(&c->capacity.sectors_available);
+		u64 get, old = atomic64_read(&c->capacity.sectors_available);
+
 		do {
 			get = min((u64) sectors + SECTORS_CACHE, old);
 
-			if (unlikely(get < sectors)) {
-				preempt_enable();
+			if (unlikely(get < sectors))
 				return disk_reservation_recalc_sectors_available(c,
 								res, sectors, flags);
-			}
 		} while (!atomic64_try_cmpxchg(&c->capacity.sectors_available,
 					       &old, old - get));
 
@@ -1224,7 +1219,6 @@ int __bch2_disk_reservation_add(struct bch_fs *c, struct disk_reservation *res,
 	pcpu->sectors_available		-= sectors;
 	pcpu->online_reserved		+= sectors;
 	res->sectors			+= sectors;
-	preempt_enable();
 	return 0;
 }
 

--- a/fs/bcachefs/alloc/discard.c
+++ b/fs/bcachefs/alloc/discard.c
@@ -76,6 +76,20 @@ void bch2_discards_to_text(struct printbuf *out, struct bch_fs *c, struct discar
 	prt_printf(out, "journal seq:\t%llu\n",			journal_cur_seq(j));
 	prt_printf(out, "journal flushed seq:\t%llu -> %llu\n",	j->flushing_seq, j->flushed_seq_ondisk);
 	prt_printf(out, "journal rewind seq:\t%llu -> %llu\n",	j->rewind_seq, j->rewind_seq_ondisk);
+
+	prt_printf(out, "In flight:\n");
+	struct bch_fs_discards *d = &c->discards;
+	guard(printbuf_indent)(out);
+	guard(printbuf_atomic)(out);
+	guard(spinlock_irq)(&d->lock);
+	darray_for_each(d->in_flight, i) {
+		prt_printf(out, "%s:%llu", i->ca->name, u64_to_bucket(i->dev_bucket).offset);
+		if (i->complete)
+			prt_str(out, " complete");
+		if (i->marking_free)
+			prt_str(out, " marking_free");
+		prt_newline(out);
+	}
 }
 
 struct discard_bio {

--- a/fs/bcachefs/alloc/discard.c
+++ b/fs/bcachefs/alloc/discard.c
@@ -16,13 +16,6 @@
 
 #include "journal/journal.h"
 
-static bool discard_opt_enabled_idx(struct bch_fs *c, unsigned dev)
-{
-	guard(rcu)();
-	struct bch_dev *ca = bch2_dev_rcu_noerror(c, dev);
-	return ca && bch2_discard_opt_enabled(c, ca);
-}
-
 static u32 dev_bucket_size(struct bch_fs *c, unsigned dev)
 {
 	guard(rcu)();
@@ -341,23 +334,24 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 		return 0;
 	}
 
-	if (discard_opt_enabled_idx(c, bucket.inode) && !c->opts.nochanges) {
-		struct bch_dev *ca = bch2_dev_get_ioref(trans->c, bucket.inode, WRITE,
-							BCH_DEV_WRITE_REF_discard_bucket);
-		if (!ca) {
-			s->not_rw += bucket_size;
-			return 0;
-		}
+	struct bch_dev *ca = bch2_dev_get_ioref(trans->c, bucket.inode, WRITE,
+						BCH_DEV_WRITE_REF_discard_bucket);
+	if (!ca) {
+		s->not_rw += bucket_size;
+		return 0;
+	}
 
+	if (bch2_discard_opt_enabled(c, ca) &&
+	    bdev_max_discard_sectors(ca->disk_sb.bdev) &&
+	    !c->opts.nochanges) {
 		ret = discard_in_flight_add(c, ca, bucket, fastpath, false);
 		if (!ret) {
 			bch2_trans_unlock(trans);
+			/* consumes ioref */
 			discard_submit(ca, bucket, fastpath);
 			s->discarded += bucket_size;
 			return 0;
 		}
-
-		enumerated_ref_put(&ca->io_ref[WRITE], BCH_DEV_WRITE_REF_discard_bucket);
 
 		if (ret == -EEXIST) {
 			s->eexist += bucket_size;
@@ -365,10 +359,13 @@ static int bch2_discard_one_bucket(struct btree_trans *trans,
 		} else {
 			s->eagain += bucket_size;
 		}
-		return ret;
 	} else {
-		return __discard_mark_free(trans, s, fastpath, &iter, a);
+		ret = __discard_mark_free(trans, s, fastpath, &iter, a);
 	}
+
+	enumerated_ref_put(&ca->io_ref[WRITE], BCH_DEV_WRITE_REF_discard_bucket);
+
+	return ret;
 }
 
 static void calculate_discard_sectors_to_release(struct btree_trans *trans)
@@ -445,6 +442,7 @@ static void calculate_discard_sectors_to_release(struct btree_trans *trans)
 
 static void bch2_do_discards(struct bch_fs *c)
 {
+	struct bch_fs_discards *d = &c->discards;
 	int ret = 0;
 	bool again;
 	unsigned flushed_wb = 0;
@@ -478,9 +476,29 @@ static void bch2_do_discards(struct bch_fs *c)
 			int ret2 = bch2_discard_one_bucket(trans,
 						bucket, bucket_size,
 						s, false);
-			if (ret2 == -BCH_ERR_max_discards_in_flight)
+			/*
+			 * Reap completed discards as we go: in_flight entries
+			 * are only freed in bch2_discards_complete(), so if we
+			 * never reach DEV_IN_FLIGHT_MAX - the device completes
+			 * discards inline, or doesn't support REQ_OP_DISCARD -
+			 * the in_flight darray would otherwise grow without
+			 * bound and turn the linear scans in
+			 * discard_in_flight_add()/discard_endio() into O(n^2).
+			 * in_flight.nr > ref means there are completed entries
+			 * waiting to be reaped.
+			 *
+			 * On success the bucket's been handled, so advance the
+			 * iterator before the nested restart so we don't
+			 * reprocess it; on -max_discards_in_flight leave it put
+			 * so we retry the bucket after draining.
+			 */
+			if (ret2 == -BCH_ERR_max_discards_in_flight ||
+			    (!ret2 && READ_ONCE(d->in_flight.nr) > READ_ONCE(d->ref))) {
+				if (!ret2)
+					bch2_btree_iter_advance(&iter);
 				ret2 = bch2_discards_complete(trans, s, false, false) ?:
 				btree_trans_restart(trans, BCH_ERR_transaction_restart_nested);
+			}
 			ret2;
 		}));
 

--- a/fs/bcachefs/alloc/foreground.c
+++ b/fs/bcachefs/alloc/foreground.c
@@ -1657,8 +1657,12 @@ void bch2_fs_open_buckets_to_text(struct printbuf *out, struct bch_fs *c)
 	for (struct open_bucket *ob = a->open_buckets;
 	     ob < a->open_buckets + ARRAY_SIZE(a->open_buckets);
 	     ob++)
-		if (atomic_read(&ob->pin))
-			nr[ob->data_type]++;
+		if (atomic_read(&ob->pin)) {
+			unsigned t = ob->data_type;
+			barrier(); /* can't READ_ONCE() a bitfield */
+			if (t < BCH_DATA_NR)
+				nr[t]++;
+		}
 
 	prt_printf(out, "open buckets allocated\t%i\n",		OPEN_BUCKETS_COUNT - a->open_buckets_nr_free);
 	prt_printf(out, "open buckets total\t%u\n",		OPEN_BUCKETS_COUNT);
@@ -1701,8 +1705,12 @@ void bch2_dev_alloc_debug_to_text(struct printbuf *out, struct bch_dev *ca)
 
 	memset(nr, 0, sizeof(nr));
 
-	for (unsigned i = 0; i < ARRAY_SIZE(a->open_buckets); i++)
-		nr[a->open_buckets[i].data_type]++;
+	for (unsigned i = 0; i < ARRAY_SIZE(a->open_buckets); i++) {
+		unsigned t = a->open_buckets[i].data_type;
+		barrier(); /* can't READ_ONCE() a bitfield */
+		if (t < BCH_DATA_NR)
+			nr[t]++;
+	}
 
 	bch2_dev_usage_to_text(out, ca, &stats);
 

--- a/fs/bcachefs/alloc/foreground.c
+++ b/fs/bcachefs/alloc/foreground.c
@@ -49,6 +49,7 @@
 #include <linux/math64.h>
 #include <linux/rculist.h>
 #include <linux/rcupdate.h>
+#include <linux/sched/signal.h>
 
 static void bch2_trans_mutex_lock_norelock(struct btree_trans *trans,
 					   struct mutex *lock)

--- a/fs/bcachefs/alloc/foreground.h
+++ b/fs/bcachefs/alloc/foreground.h
@@ -335,6 +335,7 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	req->ca				= NULL;
 	req->cl				= cl;
 	req->nr_replicas		= nr_replicas;
+	req->nr_effective		= 0;
 	req->ec_replicas		= ec_replicas;
 	req->ec				= erasure_code;
 	req->target			= target;
@@ -347,6 +348,10 @@ static inline struct alloc_request *alloc_request_get(struct btree_trans *trans,
 	req->will_retry_set_devices	= false;
 	req->copygc_can_make_progress	= false;
 	req->trace_alloc_failed		= false;
+	req->devs_sorted.nr		= 0;
+	/* bch2_alloc_sectors_req() overwrites this; bch2_bucket_alloc_trans()
+	 * callers (e.g. journal resize) don't, so zero it here for them: */
+	memset(&req->devs_may_alloc, 0, sizeof(req->devs_may_alloc));
 	darray_init(&req->trace);
 	return req;
 }

--- a/fs/bcachefs/alloc/types.h
+++ b/fs/bcachefs/alloc/types.h
@@ -154,7 +154,7 @@ struct bch_fs_capacity {
 	unsigned		bucket_size_max;
 
 	atomic64_t		sectors_available;
-	struct mutex		sectors_available_lock;
+	spinlock_t		sectors_available_lock;
 
 	struct bch_fs_capacity_pcpu __percpu	*pcpu;
 

--- a/fs/bcachefs/alloc/types.h
+++ b/fs/bcachefs/alloc/types.h
@@ -50,7 +50,7 @@ struct open_bucket {
 	 * the block in the stripe this open_bucket corresponds to:
 	 */
 	u8			ec_idx;
-	enum bch_data_type	data_type:6;
+	enum bch_data_type	data_type:5;
 	bool			valid:1;
 	bool			on_partial_list:1;
 	bool			do_discards_fast:1;

--- a/fs/bcachefs/bcachefs_format.h
+++ b/fs/bcachefs/bcachefs_format.h
@@ -542,6 +542,23 @@ struct bch_backpointer {
 	struct bpos		pos;
 } __packed __aligned(8);
 
+/*
+ * Denormalized cache of "is this bp's extent listed in reconcile_phys?":
+ *
+ * fsck needs to check that the reconcile_phys btrees agree with the extents
+ * btree, but a direct reconcile_phys <-> extents check would be expensive:
+ * for every reconcile_phys entry (keyed by bucket position), we'd have to do
+ * a random lookup against the extents btree. Instead, mirror the work_id into
+ * the backpointer so fsck can do two cheap pairwise checks:
+ *
+ *   - reconcile_phys <-> backpointers: both keyed by bucket position, indexed
+ *   - backpointers   <-> extents:	already required for backpointer fsck
+ *
+ * Invariant: when bp.flags PHYS != 0, reconcile_phys[PHYS] must have an entry
+ * at bp.k.p, and the extent must carry a bch_extent_reconcile entry whose
+ * rb_work_id_phys() equals PHYS. Every path that mutates reconcile_opts on an
+ * extent must keep the bp's PHYS flag in sync.
+ */
 BITMASK(BACKPOINTER_RECONCILE_PHYS,	struct bch_backpointer, flags, 0, 2);
 BITMASK(BACKPOINTER_ERASURE_CODED,	struct bch_backpointer, flags, 2, 3);
 BITMASK(BACKPOINTER_STRIPE_PTR,		struct bch_backpointer, flags, 3, 4);

--- a/fs/bcachefs/btree/cache.c
+++ b/fs/bcachefs/btree/cache.c
@@ -797,6 +797,7 @@ void bch2_btree_cache_cannibalize_unlock(struct btree_trans *trans)
 		bc->alloc_lock = NULL;
 		closure_wake_up(&bc->alloc_wait);
 	}
+	trans->btree_cache_cannibalize_locked = false;
 }
 
 static int __btree_cache_cannibalize_lock(struct bch_fs *c, struct closure *cl)
@@ -828,10 +829,12 @@ int bch2_btree_cache_cannibalize_lock(struct btree_trans *trans, struct closure 
 {
 	struct bch_fs *c = trans->c;
 	int ret = __btree_cache_cannibalize_lock(c, cl);
-	if (!ret)
+	if (!ret) {
+		trans->btree_cache_cannibalize_locked = true;
 		event_inc_trace(c, btree_cache_cannibalize_lock, buf, prt_str(&buf, trans->fn));
-	else
+	} else {
 		event_inc_trace(c, btree_cache_cannibalize_lock_fail, buf, prt_str(&buf, trans->fn));
+	}
 	return ret;
 }
 

--- a/fs/bcachefs/btree/locking.c
+++ b/fs/bcachefs/btree/locking.c
@@ -1030,6 +1030,18 @@ void bch2_trans_unlock(struct btree_trans *trans)
 	trans_set_unlocked(trans);
 
 	__bch2_trans_unlock(trans);
+
+	/*
+	 * Drop the btree cache cannibalize lock too. Holding it across a
+	 * trans_unlock - i.e. across a sleep - is the recipe for a resource
+	 * deadlock: cannibalize-holder sleeps waiting on the allocator,
+	 * allocator needs to grow the btree cache, growing the cache needs
+	 * cannibalize, but we're holding it. Releasing on trans_unlock means
+	 * cannibalize is only held over non-sleeping critical sections;
+	 * callers that need it after a wake re-acquire normally.
+	 */
+	if (unlikely(trans->btree_cache_cannibalize_locked))
+		bch2_btree_cache_cannibalize_unlock(trans);
 }
 
 void bch2_trans_unlock_long(struct btree_trans *trans)

--- a/fs/bcachefs/btree/types.h
+++ b/fs/bcachefs/btree/types.h
@@ -650,6 +650,7 @@ struct btree_trans {
 	bool			locked:1;
 	bool			write_locked:1;
 	bool			srcu_held:1;
+	bool			btree_cache_cannibalize_locked:1;
 	bool			pf_memalloc_nofs:1;
 	bool			used_mempool:1;
 	bool			in_traverse_all:1;

--- a/fs/bcachefs/data/move.c
+++ b/fs/bcachefs/data/move.c
@@ -49,6 +49,7 @@ const char * const bch2_data_ops_strs[] = {
 struct evacuate_bucket_arg {
 	struct bpos		bucket;
 	int			gen;
+	u32			sectors;
 	struct data_update_opts	data_opts;
 };
 
@@ -811,12 +812,16 @@ static int evacuate_bucket_pred(struct btree_trans *trans, void *_arg,
 	*data_opts = arg->data_opts;
 	data_opts->read_dev = -1;
 
+	const union bch_extent_entry *entry;
+	struct extent_ptr_decoded p;
 	unsigned i = 0;
-	bkey_for_each_ptr(bch2_bkey_ptrs_c(k), ptr) {
-		if (ptr->dev == arg->bucket.inode &&
-		    (arg->gen < 0 || arg->gen == ptr->gen) &&
-		    !ptr->cached)
+	bkey_for_each_ptr_decode(k.k, bch2_bkey_ptrs_c(k), p, entry) {
+		if (p.ptr.dev == arg->bucket.inode &&
+		    (arg->gen < 0 || arg->gen == p.ptr.gen) &&
+		    !p.ptr.cached) {
 			data_opts->ptrs_kill |= BIT(i);
+			arg->sectors += p.crc.compressed_size;
+		}
 		i++;
 	}
 
@@ -829,7 +834,7 @@ int bch2_evacuate_bucket(struct moving_context *ctxt,
 			 struct data_update_opts data_opts)
 {
 	struct bch_fs *c = ctxt->trans->c;
-	struct evacuate_bucket_arg arg = { bucket, gen, data_opts, };
+	struct evacuate_bucket_arg arg = { bucket, gen, 0, data_opts, };
 
 	/* Userspace might have supplied @dev: */
 	CLASS(bch2_dev_tryget_noerror, ca)(c, bucket.inode);
@@ -850,6 +855,7 @@ int bch2_evacuate_bucket(struct moving_context *ctxt,
 		prt_printf(&buf, "bucket: ");
 		bch2_bpos_to_text(&buf, bucket);
 		prt_printf(&buf, " gen: %i ret %s\n", gen, bch2_err_str(ret));
+		prt_printf(&buf, "%u/%u sectors\n", arg.sectors, ca->mi.bucket_size);
 	}));
 
 	return ret;

--- a/fs/bcachefs/data/reconcile/types.h
+++ b/fs/bcachefs/data/reconcile/types.h
@@ -6,6 +6,9 @@
 #include "data/move_types.h"
 #include "init/progress.h"
 
+#include <linux/mutex.h>
+#include <linux/rhashtable-types.h>
+
 struct bch_fs_reconcile {
 	struct task_struct __rcu	*thread;
 	u32				kick;
@@ -23,6 +26,11 @@ struct bch_fs_reconcile {
 	struct bbpos			scan_start;
 	struct bbpos			scan_end;
 	struct bch_move_stats		scan_stats;
+
+	/* In-flight opt changes - see bch2_set_reconcile_needs_scan_pre/post() */
+	struct rhashtable		scans_in_flight;
+	bool				scans_in_flight_init_done;
+	struct mutex			scans_in_flight_lock;
 
 	bool				on_battery;
 #ifdef CONFIG_POWER_SUPPLY

--- a/fs/bcachefs/data/reconcile/work.c
+++ b/fs/bcachefs/data/reconcile/work.c
@@ -242,41 +242,51 @@ static void reconcile_scan_in_flight_put(struct bch_fs *c, u64 cookie)
 	}
 }
 
+static void opt_change_scope_push(struct opt_change_scope *scope, u64 cookie)
+{
+	BUG_ON(scope->nr >= ARRAY_SIZE(scope->cookies));
+	scope->cookies[scope->nr++] = cookie;
+}
+
+void bch2_opt_change_scope_exit(struct opt_change_scope *scope)
+{
+	while (scope->nr)
+		reconcile_scan_in_flight_put(scope->c, scope->cookies[--scope->nr]);
+}
+
 /*
- * An opt change is about to start: register the cookie so the reconcile thread
- * won't complete a pass against the intermediate state, then bump the cookie so
- * writers' extent triggers re-derive against the new option as it lands. Must
- * be paired with bch2_set_reconcile_needs_scan_post().
+ * An opt change is about to start: register the cookie (recording it in the
+ * caller's opt_change_scope, whose destructor unregisters it) so the reconcile
+ * thread won't complete a pass against the intermediate state, then bump the
+ * cookie so writers' extent triggers re-derive against the new option as it
+ * lands. Should be paired with bch2_set_reconcile_needs_scan_post() once the
+ * change has settled - but the registration is dropped by the scope destructor
+ * regardless, so an erroring-out change doesn't strand it.
  */
-int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s)
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s,
+				      struct opt_change_scope *scope)
 {
 	u64 cookie = reconcile_scan_encode(s);
 
 	try(reconcile_scan_in_flight_get(c, cookie));
+	opt_change_scope_push(scope, cookie);
 
 	CLASS(btree_trans, trans)(c);
-	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
-			    bch2_set_reconcile_needs_scan_trans(trans, s));
-	if (ret)
-		reconcile_scan_in_flight_put(c, cookie);
-	return ret;
+	return commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			 bch2_set_reconcile_needs_scan_trans(trans, s));
 }
 
 /*
- * The opt change is done (or failed): bump the cookie to reflect the settled
- * option, unregister, and kick the reconcile thread. The unregister and the
- * wakeup happen even if the cookie bump failed - the pre-set bump still stands,
- * so a later pass will scan against whatever the option settled to.
+ * The opt change has settled: bump the cookie again so it reflects the new
+ * option, and kick the reconcile thread. (The in-flight registration is
+ * released by the caller's opt_change_scope destructor, not here.)
  */
 int bch2_set_reconcile_needs_scan_post(struct bch_fs *c, struct reconcile_scan s)
 {
-	u64 cookie = reconcile_scan_encode(s);
-
 	CLASS(btree_trans, trans)(c);
 	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
 			    bch2_set_reconcile_needs_scan_trans(trans, s));
 
-	reconcile_scan_in_flight_put(c, cookie);
 	bch2_reconcile_wakeup(c);
 	return ret;
 }

--- a/fs/bcachefs/data/reconcile/work.c
+++ b/fs/bcachefs/data/reconcile/work.c
@@ -159,6 +159,128 @@ int bch2_set_reconcile_needs_scan(struct bch_fs *c, struct reconcile_scan s, boo
 	return 0;
 }
 
+/*
+ * In-flight opt changes:
+ *
+ * An opt change is a multi-step operation - it brackets the actual change with
+ * scan-cookie bumps (see opts.c) so writers' extent triggers re-derive against
+ * the new option as it lands. But the reconcile thread mustn't *complete*
+ * (delete) a scan cookie for a pass that overlapped a half-applied opt change:
+ * such a pass scanned against the intermediate option value, and on the
+ * ERO/error path nothing bumps the cookie afterwards to force another pass. So
+ * an opt change registers the cookie it touches here for its duration;
+ * bch2_clear_reconcile_needs_scan() refuses to delete a registered cookie.
+ *
+ * Refcounted: more than one opt change can target the same cookie at once.
+ *
+ * Registration also lets the reconcile thread skip *starting* a scan it
+ * couldn't complete anyway - but that's just sparing wasted work; the
+ * don't-delete is what's load-bearing.
+ */
+struct reconcile_scan_in_flight {
+	struct rhash_head	hash;
+	u64			cookie;
+	unsigned		ref;	/* protected by scans_in_flight_lock */
+	struct rcu_head		rcu;
+};
+
+static const struct rhashtable_params reconcile_scan_in_flight_params = {
+	.head_offset		= offsetof(struct reconcile_scan_in_flight, hash),
+	.key_offset		= offsetof(struct reconcile_scan_in_flight, cookie),
+	.key_len		= sizeof(u64),
+	.automatic_shrinking	= true,
+};
+
+/* Lockless - called by the reconcile thread when deciding whether to clear a cookie: */
+static bool reconcile_scan_in_flight(struct bch_fs *c, u64 cookie)
+{
+	return rhashtable_lookup_fast(&c->reconcile.scans_in_flight, &cookie,
+				      reconcile_scan_in_flight_params) != NULL;
+}
+
+static int reconcile_scan_in_flight_get(struct bch_fs *c, u64 cookie)
+{
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	guard(mutex)(&r->scans_in_flight_lock);
+
+	struct reconcile_scan_in_flight *e =
+		rhashtable_lookup_fast(&r->scans_in_flight, &cookie,
+				       reconcile_scan_in_flight_params);
+	if (e) {
+		e->ref++;
+		return 0;
+	}
+
+	e = kzalloc(sizeof(*e), GFP_KERNEL);
+	if (!e)
+		return bch_err_throw(c, ENOMEM_reconcile_scan_in_flight);
+	e->cookie	= cookie;
+	e->ref		= 1;
+
+	int ret = rhashtable_insert_fast(&r->scans_in_flight, &e->hash,
+					 reconcile_scan_in_flight_params);
+	if (ret)
+		kfree(e);
+	return ret;
+}
+
+static void reconcile_scan_in_flight_put(struct bch_fs *c, u64 cookie)
+{
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	guard(mutex)(&r->scans_in_flight_lock);
+
+	struct reconcile_scan_in_flight *e =
+		rhashtable_lookup_fast(&r->scans_in_flight, &cookie,
+				       reconcile_scan_in_flight_params);
+	BUG_ON(!e);
+	if (!--e->ref) {
+		BUG_ON(rhashtable_remove_fast(&r->scans_in_flight, &e->hash,
+					      reconcile_scan_in_flight_params));
+		kfree_rcu(e, rcu);
+	}
+}
+
+/*
+ * An opt change is about to start: register the cookie so the reconcile thread
+ * won't complete a pass against the intermediate state, then bump the cookie so
+ * writers' extent triggers re-derive against the new option as it lands. Must
+ * be paired with bch2_set_reconcile_needs_scan_post().
+ */
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *c, struct reconcile_scan s)
+{
+	u64 cookie = reconcile_scan_encode(s);
+
+	try(reconcile_scan_in_flight_get(c, cookie));
+
+	CLASS(btree_trans, trans)(c);
+	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			    bch2_set_reconcile_needs_scan_trans(trans, s));
+	if (ret)
+		reconcile_scan_in_flight_put(c, cookie);
+	return ret;
+}
+
+/*
+ * The opt change is done (or failed): bump the cookie to reflect the settled
+ * option, unregister, and kick the reconcile thread. The unregister and the
+ * wakeup happen even if the cookie bump failed - the pre-set bump still stands,
+ * so a later pass will scan against whatever the option settled to.
+ */
+int bch2_set_reconcile_needs_scan_post(struct bch_fs *c, struct reconcile_scan s)
+{
+	u64 cookie = reconcile_scan_encode(s);
+
+	CLASS(btree_trans, trans)(c);
+	int ret = commit_do(trans, NULL, NULL, BCH_TRANS_COMMIT_no_enospc,
+			    bch2_set_reconcile_needs_scan_trans(trans, s));
+
+	reconcile_scan_in_flight_put(c, cookie);
+	bch2_reconcile_wakeup(c);
+	return ret;
+}
+
 int bch2_set_fs_needs_reconcile(struct bch_fs *c)
 {
 	return bch2_set_reconcile_needs_scan(c,
@@ -1094,6 +1216,16 @@ static int do_reconcile_scan(struct moving_context *ctxt,
 	struct bch_fs *c = trans->c;
 	struct bch_fs_reconcile *r = &c->reconcile;
 
+	/*
+	 * If an opt change is still mid-flight for this cookie we couldn't
+	 * complete the scan anyway - bch2_clear_reconcile_needs_scan() would
+	 * refuse to delete the cookie - so don't burn a full pass on it;
+	 * bch2_set_reconcile_needs_scan_post()'s wakeup brings us back once the
+	 * change settles.
+	 */
+	if (reconcile_scan_in_flight(c, cookie_pos.offset))
+		return 0;
+
 	bch2_move_stats_init(&r->scan_stats, "reconcile_scan");
 	ctxt->stats = &r->scan_stats;
 
@@ -1788,18 +1920,34 @@ static int bch2_reconcile_power_notifier(struct notifier_block *nb,
 }
 #endif
 
+static void reconcile_scan_in_flight_free(void *p, void *arg)
+{
+	WARN_ON_ONCE(1);
+	kfree(p);
+}
+
 void bch2_fs_reconcile_exit(struct bch_fs *c)
 {
+	struct bch_fs_reconcile *r = &c->reconcile;
+
+	if (r->scans_in_flight_init_done)
+		rhashtable_free_and_destroy(&r->scans_in_flight,
+					    reconcile_scan_in_flight_free, NULL);
+
 #ifdef CONFIG_POWER_SUPPLY
-	power_supply_unreg_notifier(&c->reconcile.power_notifier);
+	power_supply_unreg_notifier(&r->power_notifier);
 #endif
 }
 
 int bch2_fs_reconcile_init(struct bch_fs *c)
 {
-#ifdef CONFIG_POWER_SUPPLY
 	struct bch_fs_reconcile *r = &c->reconcile;
 
+	mutex_init(&r->scans_in_flight_lock);
+	try(rhashtable_init(&r->scans_in_flight, &reconcile_scan_in_flight_params));
+	r->scans_in_flight_init_done = true;
+
+#ifdef CONFIG_POWER_SUPPLY
 	r->power_notifier.notifier_call = bch2_reconcile_power_notifier;
 	try(power_supply_reg_notifier(&r->power_notifier));
 

--- a/fs/bcachefs/data/reconcile/work.h
+++ b/fs/bcachefs/data/reconcile/work.h
@@ -30,6 +30,8 @@ struct reconcile_scan {
 
 int bch2_set_reconcile_needs_scan_trans(struct btree_trans *, struct reconcile_scan);
 int bch2_set_reconcile_needs_scan(struct bch_fs *, struct reconcile_scan, bool);
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan);
+int bch2_set_reconcile_needs_scan_post(struct bch_fs *, struct reconcile_scan);
 int bch2_set_fs_needs_reconcile(struct bch_fs *);
 
 int bch2_reconcile_scan_cookie_is_set(struct btree_trans *, u64);

--- a/fs/bcachefs/data/reconcile/work.h
+++ b/fs/bcachefs/data/reconcile/work.h
@@ -28,9 +28,37 @@ struct reconcile_scan {
 	};
 };
 
+/* No opt change touches more than one bracketed reconcile scan today: */
+#define BCH_OPT_CHANGE_SCANS_MAX	4
+
+/*
+ * The reconcile-scan cookies an opt change registered as in-flight - see
+ * bch2_set_reconcile_needs_scan_pre(). Constructed empty, populated by
+ * bch2_opt_hook_pre_set(); the destructor unregisters them, so an opt change
+ * that errors out (or never reaches bch2_opt_hook_post_set()) doesn't leak a
+ * registration and wedge the reconcile thread on that cookie.
+ */
+struct opt_change_scope {
+	struct bch_fs		*c;
+	unsigned		nr;
+	u64			cookies[BCH_OPT_CHANGE_SCANS_MAX];
+};
+
+static inline struct opt_change_scope bch2_opt_change_scope_init(struct bch_fs *c)
+{
+	return (struct opt_change_scope) { .c = c };
+}
+
+void bch2_opt_change_scope_exit(struct opt_change_scope *);
+
+DEFINE_CLASS(opt_change_scope, struct opt_change_scope,
+	     bch2_opt_change_scope_exit(&_T),
+	     bch2_opt_change_scope_init(c),
+	     struct bch_fs *c);
+
 int bch2_set_reconcile_needs_scan_trans(struct btree_trans *, struct reconcile_scan);
 int bch2_set_reconcile_needs_scan(struct bch_fs *, struct reconcile_scan, bool);
-int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan);
+int bch2_set_reconcile_needs_scan_pre(struct bch_fs *, struct reconcile_scan, struct opt_change_scope *);
 int bch2_set_reconcile_needs_scan_post(struct bch_fs *, struct reconcile_scan);
 int bch2_set_fs_needs_reconcile(struct bch_fs *);
 

--- a/fs/bcachefs/data/reflink.c
+++ b/fs/bcachefs/data/reflink.c
@@ -470,6 +470,19 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	if (orig->k.type == KEY_TYPE_inline_data)
 		bch2_check_set_feature(c, BCH_FEATURE_reflink_inline_data);
 
+	/*
+	 * A non-degraded extent carries no bch_extent_reconcile entry - for a
+	 * data extent that's fine, reconcile re-derives the io options from the
+	 * inode each pass. But once it's indirect there's no inode to derive
+	 * from, so snapshot the inode's options onto the reflink_v now;
+	 * otherwise reconcile would reconcile it against the filesystem
+	 * defaults instead. (If the source extent already carries the entry,
+	 * or the inode's options match the defaults, this is a no-op.) The
+	 * kmalloc below reserves room for the entry + invalid-device padding.
+	 */
+	struct bch_inode_opts opts;
+	try(bch2_bkey_get_io_opts(trans, NULL, bkey_i_to_s_c(orig), &opts));
+
 	CLASS(btree_iter, reflink_iter)(trans, BTREE_ID_reflink, POS_MAX,
 					BTREE_ITER_intent);
 	bkey_try(bch2_btree_iter_peek_prev(&reflink_iter));
@@ -482,7 +495,8 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	if (bkey_ge(reflink_iter.pos, POS(0, REFLINK_P_IDX_MAX - orig->k.size)))
 		return -ENOSPC;
 
-	struct bkey_i *r_v = errptr_try(bch2_trans_kmalloc(trans, sizeof(__le64) + bkey_bytes(&orig->k)));
+	unsigned r_v_buf_u64s = orig->k.u64s + 2 + BCH_REPLICAS_MAX;
+	struct bkey_i *r_v = errptr_try(bch2_trans_kmalloc(trans, r_v_buf_u64s * sizeof(u64)));
 
 	bkey_init(&r_v->k);
 	r_v->k.type	= bkey_type_to_indirect(&orig->k);
@@ -495,6 +509,9 @@ static int bch2_make_extent_indirect(struct btree_trans *trans,
 	__le64 *refcount = bkey_refcount(bkey_i_to_s(r_v));
 	*refcount	= 0;
 	memcpy(refcount + 1, &orig->v, bkey_val_bytes(&orig->k));
+
+	try(bch2_bkey_set_needs_reconcile(trans, NULL, &opts, bkey_i_to_s(r_v),
+					  r_v_buf_u64s, SET_NEEDS_RECONCILE_other, 0));
 
 	try(bch2_trans_update(trans, &reflink_iter, r_v, 0));
 

--- a/fs/bcachefs/debug/sysfs.c
+++ b/fs/bcachefs/debug/sysfs.c
@@ -801,10 +801,11 @@ static ssize_t sysfs_opt_store(struct bch_fs *c,
 
 	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
 	guard(opt_change_lock)(c);
+	CLASS(opt_change_scope, opt_scope)(c);
 
 	u64 v;
 	ret =   bch2_opt_parse(c, opt, strim(tmp), &v, NULL) ?:
-		bch2_opt_hook_pre_set(c, ca, 0, id, v, true);
+		bch2_opt_hook_pre_set(c, ca, 0, id, v, true, &opt_scope);
 
 	if (!ret) {
 		bool is_sb = opt->get_sb || opt->get_member || opt->get_ext;

--- a/fs/bcachefs/errcode.h
+++ b/fs/bcachefs/errcode.h
@@ -156,6 +156,7 @@
 	x(ENOMEM,                       ENOMEM_journal_read_bucket)             \
 	x(ENOMEM,                       ENOMEM_acl)				\
 	x(ENOMEM,                       ENOMEM_move_extent)			\
+	x(ENOMEM,			ENOMEM_reconcile_scan_in_flight)	\
 	x(ENOSPC,			ENOSPC_disk_reservation)		\
 	x(ENOSPC,			ENOSPC_bucket_alloc)			\
 	x(ENOSPC,			ENOSPC_disk_label_add)			\

--- a/fs/bcachefs/fs/xattr.c
+++ b/fs/bcachefs/fs/xattr.c
@@ -526,6 +526,7 @@ static int __bch2_xattr_bcachefs_set(const struct xattr_handler *handler,
 
 	guard(memalloc_flags)(PF_MEMALLOC_NOFS);
 	guard(opt_change_lock)(c);
+	CLASS(opt_change_scope, opt_scope)(c);
 
 	if (value) {
 		char *buf __free(kfree) = kmalloc(size + 1, GFP_KERNEL);
@@ -535,7 +536,7 @@ static int __bch2_xattr_bcachefs_set(const struct xattr_handler *handler,
 		buf[size] = '\0';
 
 		try(bch2_opt_parse(c, opt, buf, &v, NULL));
-		try(bch2_opt_hook_pre_set(c, NULL, inode->ei_inode.bi_inum, opt_id, v, true));
+		try(bch2_opt_hook_pre_set(c, NULL, inode->ei_inode.bi_inum, opt_id, v, true, &opt_scope));
 
 		/* +1 bias for inode options: */
 		s.v = v + 1;

--- a/fs/bcachefs/opts.c
+++ b/fs/bcachefs/opts.c
@@ -568,8 +568,16 @@ void bch2_opts_to_text(struct printbuf *out,
 	}
 }
 
+static int reconcile_scan_bracket(struct bch_fs *c, struct reconcile_scan s, bool post,
+				  struct opt_change_scope *scope)
+{
+	return post
+		? bch2_set_reconcile_needs_scan_post(c, s)
+		: bch2_set_reconcile_needs_scan_pre(c, s, scope);
+}
+
 static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_opt_id id,
-		       u64 v, bool post)
+		       u64 v, bool post, struct opt_change_scope *scope)
 {
 	if (!test_bit(BCH_FS_started, &c->flags))
 		return 0;
@@ -589,22 +597,22 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 			.inum = inum,
 		};
 
-		try(bch2_set_reconcile_needs_scan(c, s, post));
+		try(reconcile_scan_bracket(c, s, post, scope));
 		break;
 	}
 	case Opt_metadata_target:
 	case Opt_metadata_checksum:
 	case Opt_metadata_replicas:
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_metadata, .dev = inum }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_metadata, .dev = inum }, post, scope));
 		break;
 	case Opt_durability:
 		if (!post && v > ca->mi.durability)
 			try(bch2_set_reconcile_needs_scan(c,
-				(struct reconcile_scan) { .type = RECONCILE_SCAN_pending}, post));
+				(struct reconcile_scan) { .type = RECONCILE_SCAN_pending}, false));
 
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_device, .dev = inum }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_device, .dev = inum }, post, scope));
 		break;
 	case Opt_ec_max_data_blocks:
 		/*
@@ -613,8 +621,8 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 		 * stripes scan so existing stripes converge to the new
 		 * target.
 		 */
-		try(bch2_set_reconcile_needs_scan(c,
-			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post));
+		try(reconcile_scan_bracket(c,
+			(struct reconcile_scan) { .type = RECONCILE_SCAN_stripes }, post, scope));
 		break;
 	default:
 		break;
@@ -624,7 +632,7 @@ static int opt_hook_io(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_
 }
 
 int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum bch_opt_id id, u64 v,
-			  bool change)
+			  bool change, struct opt_change_scope *scope)
 {
 	switch (id) {
 	case Opt_state:
@@ -651,7 +659,7 @@ int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum b
 	}
 
 	if (change)
-		try(opt_hook_io(c, ca, inum, id, v, false));
+		try(opt_hook_io(c, ca, inum, id, v, false, scope));
 
 	return 0;
 }
@@ -659,7 +667,7 @@ int bch2_opt_hook_pre_set(struct bch_fs *c, struct bch_dev *ca, u64 inum, enum b
 int bch2_opts_hooks_pre_set(struct bch_fs *c)
 {
 	for (unsigned i = 0; i < bch2_opts_nr; i++)
-		try(bch2_opt_hook_pre_set(c, NULL, 0, i, bch2_opt_get_by_id(&c->opts, i), false));
+		try(bch2_opt_hook_pre_set(c, NULL, 0, i, bch2_opt_get_by_id(&c->opts, i), false, NULL));
 
 	return 0;
 }
@@ -678,7 +686,7 @@ void bch2_opt_hook_post_set(struct bch_fs *c, struct bch_dev *ca, u64 inum,
 		bch2_fs_log_msg(c, "%s", buf.buf);
 	}
 
-	opt_hook_io(c, ca, inum, id, v, true);
+	opt_hook_io(c, ca, inum, id, v, true, NULL);
 
 	switch (id) {
 	case Opt_reconcile_enabled:

--- a/fs/bcachefs/opts.c
+++ b/fs/bcachefs/opts.c
@@ -9,6 +9,8 @@
 #include "alloc/background.h"
 #include "alloc/disk_groups.h"
 
+#include "btree/update.h"
+
 #include "data/compress.h"
 #include "data/copygc.h"
 #include "data/reconcile/work.h"
@@ -665,6 +667,17 @@ int bch2_opts_hooks_pre_set(struct bch_fs *c)
 void bch2_opt_hook_post_set(struct bch_fs *c, struct bch_dev *ca, u64 inum,
 			    enum bch_opt_id id, u64 v)
 {
+	if (test_bit(BCH_FS_started, &c->flags)) {
+		CLASS(printbuf, buf)();
+		prt_printf(&buf, "opt change: %s=", bch2_opt_table[id].attr.name);
+		bch2_opt_to_text(&buf, c, c->disk_sb.sb, &bch2_opt_table[id], v, 0);
+		if (ca)
+			prt_printf(&buf, " dev %u", ca->dev_idx);
+		if (inum)
+			prt_printf(&buf, " inum %llu", inum);
+		bch2_fs_log_msg(c, "%s", buf.buf);
+	}
+
 	opt_hook_io(c, ca, inum, id, v, true);
 
 	switch (id) {

--- a/fs/bcachefs/opts.h
+++ b/fs/bcachefs/opts.h
@@ -699,7 +699,9 @@ void bch2_opts_to_text(struct printbuf *,
 		       struct bch_opts_mask *,
 		       unsigned, unsigned, unsigned);
 
-int bch2_opt_hook_pre_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64, bool);
+struct opt_change_scope;
+int bch2_opt_hook_pre_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64, bool,
+			  struct opt_change_scope *);
 int bch2_opts_hooks_pre_set(struct bch_fs *);
 void bch2_opt_hook_post_set(struct bch_fs *, struct bch_dev *, u64, enum bch_opt_id, u64);
 

--- a/fs/bcachefs/snapshots/subvolume.c
+++ b/fs/bcachefs/snapshots/subvolume.c
@@ -318,7 +318,8 @@ int bch2_subvol_is_ro_trans(struct btree_trans *trans, u32 subvol)
 	struct bch_subvolume s;
 	try(bch2_subvolume_get_inlined(trans, subvol, true, &s));
 
-	if (BCH_SUBVOLUME_RO(&s))
+	if (BCH_SUBVOLUME_RO(&s) ||
+	    BCH_SUBVOLUME_UNLINKED(&s))
 		return -EROFS;
 	return 0;
 }

--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -49,23 +49,6 @@
 #include <linux/version.h>
 #include <linux/xattr.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
-static inline unsigned inode_state_read(struct inode *inode)
-{
-	return inode->i_state;
-}
-
-static inline unsigned inode_state_read_once(struct inode *inode)
-{
-	return READ_ONCE(inode->i_state);
-}
-
-static inline void inode_state_set_raw(struct inode *inode, unsigned flags)
-{
-	WRITE_ONCE(inode->i_state, inode->i_state|flags);
-}
-#endif
-
 static struct kmem_cache *bch2_inode_cache;
 
 static void bch2_vfs_inode_init(struct btree_trans *, subvol_inum,
@@ -434,8 +417,7 @@ retry:
 
 		inode_sb_list_add(&inode->v);
 
-		scoped_guard(mutex, &c->vfs.inodes_lock)
-			list_add(&inode->ei_vfs_inode_list, &c->vfs.inodes_list);
+		fast_list_set(&c->vfs.inodes, inode->ei_inodes_idx, inode);
 		return inode;
 	}
 }
@@ -462,16 +444,23 @@ static struct bch_inode_info *__bch2_new_inode(struct bch_fs *c, gfp_t gfp)
 	if (!inode)
 		return NULL;
 
+	int idx = fast_list_get_idx(&c->vfs.inodes, gfp);
+	if (idx < 0) {
+		kmem_cache_free(bch2_inode_cache, inode);
+		return NULL;
+	}
+
 	inode_init_once(&inode->v);
 	mutex_init(&inode->ei_update_lock);
 	two_state_lock_init(&inode->ei_pagecache_lock);
-	INIT_LIST_HEAD(&inode->ei_vfs_inode_list);
+	inode->ei_inodes_idx = idx;
 	inode->ei_flags = 0;
 	mutex_init(&inode->ei_quota_lock);
 	memset(&inode->ei_devs_need_flush, 0, sizeof(inode->ei_devs_need_flush));
 	INIT_DELAYED_WORK(&inode->ei_writeback_timer, bch2_vfs_writeback_fn);
 
 	if (unlikely(inode_init_always_gfp(c->vfs_sb, &inode->v, gfp))) {
+		fast_list_put_idx(&c->vfs.inodes, idx);
 		kmem_cache_free(bch2_inode_cache, inode);
 		return NULL;
 	}
@@ -490,6 +479,7 @@ static struct bch_inode_info *bch2_new_inode(struct btree_trans *trans)
 		int ret = drop_locks_do(trans, (inode = __bch2_new_inode(trans->c, GFP_NOFS)) ? 0 : -ENOMEM);
 		if (ret && inode) {
 			__destroy_inode(&inode->v);
+			fast_list_put_idx(&trans->c->vfs.inodes, inode->ei_inodes_idx);
 			kmem_cache_free(bch2_inode_cache, inode);
 		}
 		if (ret)
@@ -1938,8 +1928,8 @@ static void bch2_evict_inode(struct inode *vinode)
 		bch2_inode_hash_remove(c, inode);
 	}
 
-	scoped_guard(mutex, &c->vfs.inodes_lock)
-		list_del_init(&inode->ei_vfs_inode_list);
+	fast_list_remove(&c->vfs.inodes, inode->ei_inodes_idx);
+	inode->ei_inodes_idx = 0;
 }
 
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
@@ -1962,8 +1952,9 @@ again:
 	cond_resched();
 	this_pass_clean = true;
 
-	mutex_lock(&c->vfs.inodes_lock);
-	list_for_each_entry(inode, &c->vfs.inodes_list, ei_vfs_inode_list) {
+	rcu_read_lock();
+	struct genradix_iter iter;
+	fast_list_for_each(&c->vfs.inodes, iter, inode) {
 		if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
 			continue;
 
@@ -1982,14 +1973,14 @@ again:
 			wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
 			prepare_to_wait_event(wq_head, &wqe.wq_entry,
 					      TASK_UNINTERRUPTIBLE);
-			mutex_unlock(&c->vfs.inodes_lock);
+			rcu_read_unlock();
 
 			schedule();
 			finish_wait(wq_head, &wqe.wq_entry);
 			goto again;
 		}
 	}
-	mutex_unlock(&c->vfs.inodes_lock);
+	rcu_read_unlock();
 
 	darray_for_each(grabbed, i) {
 		inode = *i;
@@ -2489,13 +2480,13 @@ void bch2_fs_vfs_exit(struct bch_fs *c)
 		rhltable_destroy(&c->vfs.inodes_by_inum_table);
 	if (c->vfs.inodes_table.tbl)
 		rhashtable_destroy(&c->vfs.inodes_table);
+	fast_list_exit(&c->vfs.inodes);
 }
 
 int bch2_fs_vfs_init(struct bch_fs *c)
 {
 	fdm_init(&c->fdm_table);
-	INIT_LIST_HEAD(&c->vfs.inodes_list);
-	mutex_init(&c->vfs.inodes_lock);
+	try(fast_list_init(&c->vfs.inodes));
 
 	try(rhashtable_init(&c->vfs.inodes_table, &bch2_vfs_inodes_params));
 	try(rhltable_init(&c->vfs.inodes_by_inum_table, &bch2_vfs_inodes_by_inum_params));

--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -1131,10 +1131,24 @@ int bch2_setattr_nonsize(struct mnt_idmap *idmap,
 		qid.q[QTYP_GRP] = from_kgid(i_user_ns(&inode->v), kgid);
 	}
 
+	struct bch_qid old_qid = inode->ei_qid;
+
 	try(bch2_fs_quota_transfer(c, inode, qid, ~0, KEY_TYPE_QUOTA_PREALLOC));
 
 	CLASS(btree_trans, trans)(c);
-	return lockrestart_do(trans, bch2_setattr_nonsize_trans(trans, idmap, inode, attr));
+	int ret = lockrestart_do(trans, bch2_setattr_nonsize_trans(trans, idmap, inode, attr));
+	if (unlikely(ret))
+		/*
+		 * Roll back the in-memory quota transfer: the btree commit
+		 * failed, so the inode on disk still has the old qid. Without
+		 * this rollback, in-memory quota counts diverge from what an
+		 * inode scan would compute - generic/270 catches it.
+		 *
+		 * NOCHECK because we're returning to a qid we just came from;
+		 * it had room.
+		 */
+		bch2_fs_quota_transfer(c, inode, old_qid, ~0, KEY_TYPE_QUOTA_NOCHECK);
+	return ret;
 }
 
 static int bch2_getattr(struct mnt_idmap *idmap,

--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -1935,7 +1935,6 @@ static void bch2_evict_inode(struct inode *vinode)
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 {
 	struct bch_inode_info *inode;
-	DARRAY(struct bch_inode_info *) grabbed;
 	bool clean_pass = false, this_pass_clean;
 
 	/*
@@ -1943,11 +1942,12 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 	 * be pruned with d_mark_dontcache().
 	 *
 	 * Once we've had a clean pass where we didn't find any inodes without
-	 * I_DONTCACHE, we wait for them to be freed:
+	 * I_DONTCACHE, we wait for them to be freed.
+	 *
+	 * fast_list_iter tracks position by integer index, so we can drop rcu
+	 * around the dcache work (held safe by our igrab ref) and resume from
+	 * the same slot on the next iteration.
 	 */
-
-	darray_init(&grabbed);
-	darray_make_room(&grabbed, 1024);
 again:
 	cond_resched();
 	this_pass_clean = true;
@@ -1961,11 +1961,13 @@ again:
 		if (!(inode_state_read_once(&inode->v) & (I_DONTCACHE|I_FREEING)) &&
 		    igrab(&inode->v)) {
 			this_pass_clean = false;
+			rcu_read_unlock();
 
-			if (darray_push_gfp(&grabbed, inode, GFP_ATOMIC|__GFP_NOWARN)) {
-				iput(&inode->v);
-				break;
-			}
+			d_mark_dontcache(&inode->v);
+			d_prune_aliases(&inode->v);
+			iput(&inode->v);
+
+			rcu_read_lock();
 		} else if (clean_pass && this_pass_clean) {
 			struct wait_bit_queue_entry wqe;
 			struct wait_queue_head *wq_head;
@@ -1982,20 +1984,10 @@ again:
 	}
 	rcu_read_unlock();
 
-	darray_for_each(grabbed, i) {
-		inode = *i;
-		d_mark_dontcache(&inode->v);
-		d_prune_aliases(&inode->v);
-		iput(&inode->v);
-	}
-	grabbed.nr = 0;
-
 	if (!clean_pass || !this_pass_clean) {
 		clean_pass = this_pass_clean;
 		goto again;
 	}
-
-	darray_exit(&grabbed);
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/bcachefs/vfs/fs.c
+++ b/fs/bcachefs/vfs/fs.c
@@ -1934,9 +1934,6 @@ static void bch2_evict_inode(struct inode *vinode)
 
 void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 {
-	struct bch_inode_info *inode;
-	bool clean_pass = false, this_pass_clean;
-
 	/*
 	 * Initially, we scan for inodes without I_DONTCACHE, then mark them to
 	 * be pruned with d_mark_dontcache().
@@ -1948,19 +1945,16 @@ void bch2_evict_subvolume_inodes(struct bch_fs *c, snapshot_id_list *s)
 	 * around the dcache work (held safe by our igrab ref) and resume from
 	 * the same slot on the next iteration.
 	 */
-again:
-	cond_resched();
-	this_pass_clean = true;
-
 	rcu_read_lock();
 	struct genradix_iter iter;
+	struct bch_inode_info *inode;
+
 	fast_list_for_each(&c->vfs.inodes, iter, inode) {
 		if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
 			continue;
 
-		if (!(inode_state_read_once(&inode->v) & (I_DONTCACHE|I_FREEING)) &&
+		if (!(inode_state_read_once(&inode->v) & I_DONTCACHE) &&
 		    igrab(&inode->v)) {
-			this_pass_clean = false;
 			rcu_read_unlock();
 
 			d_mark_dontcache(&inode->v);
@@ -1968,26 +1962,31 @@ again:
 			iput(&inode->v);
 
 			rcu_read_lock();
-		} else if (clean_pass && this_pass_clean) {
-			struct wait_bit_queue_entry wqe;
-			struct wait_queue_head *wq_head;
+		}
+	}
 
-			wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
+	bool found = false;
+	do {
+		found = false;
+
+		fast_list_for_each(&c->vfs.inodes, iter, inode) {
+			if (!snapshot_list_has_id(s, inode->ei_inum.subvol))
+				continue;
+
+			found = true;
+
+			struct wait_bit_queue_entry wqe;
+			struct wait_queue_head *wq_head = inode_bit_waitqueue(&wqe, &inode->v, __I_NEW);
 			prepare_to_wait_event(wq_head, &wqe.wq_entry,
 					      TASK_UNINTERRUPTIBLE);
 			rcu_read_unlock();
 
 			schedule();
 			finish_wait(wq_head, &wqe.wq_entry);
-			goto again;
+			rcu_read_lock();
 		}
-	}
+	} while (found);
 	rcu_read_unlock();
-
-	if (!clean_pass || !this_pass_clean) {
-		clean_pass = this_pass_clean;
-		goto again;
-	}
 }
 
 static int bch2_statfs(struct dentry *dentry, struct kstatfs *buf)

--- a/fs/bcachefs/vfs/fs.h
+++ b/fs/bcachefs/vfs/fs.h
@@ -10,6 +10,24 @@
 
 #include <linux/seqlock.h>
 #include <linux/stat.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,19,0)
+static inline unsigned inode_state_read(struct inode *inode)
+{
+	return inode->i_state;
+}
+
+static inline unsigned inode_state_read_once(struct inode *inode)
+{
+	return READ_ONCE(inode->i_state);
+}
+
+static inline void inode_state_set_raw(struct inode *inode, unsigned flags)
+{
+	WRITE_ONCE(inode->i_state, inode->i_state|flags);
+}
+#endif
 
 struct bch_inode_info {
 	struct inode		v;
@@ -17,7 +35,7 @@ struct bch_inode_info {
 	struct rhlist_head	by_inum_hash;
 	subvol_inum		ei_inum;
 
-	struct list_head	ei_vfs_inode_list;
+	unsigned		ei_inodes_idx;
 	unsigned long		ei_flags;
 
 	struct mutex		ei_update_lock;

--- a/fs/bcachefs/vfs/io.c
+++ b/fs/bcachefs/vfs/io.c
@@ -373,12 +373,15 @@ static int __bch2_truncate_folio(struct bch_inode_info *inode,
 	 * writeback - doing an i_size update if necessary - or whether it will
 	 * be responsible for the i_size update.
 	 *
-	 * Note that we shouldn't ever see a folio beyond EOF, but check and
-	 * warn if so. This has been observed by failure to clean up folios
-	 * after a short write and there's still a chance reclaim will fix
-	 * things up.
+	 * We can see a folio wholly above i_size here even with the inode fully
+	 * locked: marking a folio dirty doesn't go through i_rwsem (e.g.
+	 * bio_set_pages_dirty() from a DIO read whose destination buffer is an
+	 * mmap of this file, completing after the file was truncated), so "no
+	 * dirty folios above i_size" isn't an invariant we maintain.
+	 * __bch2_writepage cleans up the per-sector dirty bits when it sees
+	 * above-i_size data; here we just need to not walk off the end of the
+	 * folio when computing end_pos.
 	 */
-	WARN_ON_ONCE(folio_pos(folio) >= inode->v.i_size);
 	end_pos = folio_end_pos(folio);
 	if (inode->v.i_size > folio_pos(folio))
 		end_pos = min_t(u64, inode->v.i_size, end_pos);

--- a/fs/bcachefs/vfs/pagecache.c
+++ b/fs/bcachefs/vfs/pagecache.c
@@ -566,15 +566,14 @@ bool bch2_set_folio_dirty(struct bch_fs *c,
 	 * Potentially a nasty performance bug, we'll be dirtying more than
 	 * we're supposed to.
 	 *
-	 * We'd like to be stricter here, we shouldn't be dirtying above i_size,
-	 * but since we're not given the correct range the uncommented warning
-	 * is the best we can do; __bch2_writepage has to fix it up.
-	 *
-	 * WARN_ON((u64) folio_pos(folio) + offset + len >
-	 *	   round_up((u64) i_size_read(&inode->v), block_bytes(c)));
+	 * We may also legitimately be dirtying folios above i_size: truncate_setsize()
+	 * drops i_size before truncate_pagecache() runs, and folios pinned by
+	 * gup (e.g. DIO read destinations into an mmap'd region of this file)
+	 * stay attached to the address_space until the pin drops. The VFS
+	 * truncate path documents this in truncate_cleanup_folio() and handles
+	 * it via folio_cancel_dirty() ordering; __bch2_writepage cleans up the
+	 * sectors_dirty bits we set here.
 	 */
-
-	WARN_ON((u64) folio_pos(folio) >= i_size_read(&inode->v));
 
 	BUG_ON(!s);
 	BUG_ON(!s->uptodate);

--- a/fs/bcachefs/vfs/types.h
+++ b/fs/bcachefs/vfs/types.h
@@ -4,9 +4,10 @@
 
 #include <linux/mempool.h>
 
+#include "util/fast_list.h"
+
 struct bch_fs_vfs {
-	struct list_head	inodes_list;
-	struct mutex		inodes_lock;
+	struct fast_list	inodes;
 	struct rhashtable	inodes_table;
 	struct rhltable		inodes_by_inum_table;
 


### PR DESCRIPTION
Historical note: this kernel-tree PR is closed/obsolete. GitHub may still show it as a scratch aggregate because the branch included current upstream commits by Kent Overstreet / Proof of Concept before the final one-commit spinlock-init fix. Those upstream commits keep their original authorship in the compare; the only proposed fix from this PR was the tail commit `bcachefs: initialize sectors_available_lock as a spinlock`.

Current `koverstreet/bcachefs` master already has the same fix, so this PR should be treated as historical only.

---

struct bch_fs_capacity::sectors_available_lock is a spinlock_t, and the users take it with spinlock helpers, but bch2_fs_capacity_init() initializes it with mutex_init(). This currently breaks a defconfig + BCACHEFS_FS=m build with -Wincompatible-pointer-types.

Use spin_lock_init() for the spinlock.

Validation:
- git diff --check
- git diff | scripts/checkpatch.pl --strict --no-tree -
- codex review --base origin/master --title "bcachefs: initialize sectors_available_lock as a spinlock"

This was also the first tail commit in the refreshed scratch aggregate because the then-current origin/master did not build without it.
