### PR TITLE
bcachefs: cancel fast discard when reusing open bucket

### DIFF
--- a/fs/bcachefs/alloc/background.c
+++ b/fs/bcachefs/alloc/background.c
@@ -1425,6 +1425,11 @@ int bch2_trigger_alloc(struct btree_trans *trans, struct btree_trigger_op op)
 				new_a->journal_seq_nonempty = transaction_seq;
 		}
 
+		if (statechange_from(a->data_type == BCH_DATA_need_discard) &&
+		    !data_type_is_empty(new_a->data_type))
+			bch2_bucket_clear_discard_fast(c, op.new.k->p.inode,
+						       op.new.k->p.offset);
+
 		if (statechange_to(a->data_type == BCH_DATA_need_discard)) {
 			/*
 			 * Bucket becomes empty: mark it as waiting for a

--- a/fs/bcachefs/alloc/foreground.h
+++ b/fs/bcachefs/alloc/foreground.h
@@ -304,6 +304,21 @@ static inline bool bch2_bucket_set_discard_fast(struct bch_fs *c, unsigned dev, 
 	return false;
 }
 
+static inline bool bch2_bucket_clear_discard_fast(struct bch_fs *c, unsigned int dev, u64 bucket)
+{
+	struct open_bucket *ob = bch2_bucket_is_open(c, dev, bucket);
+
+	if (ob) {
+		guard(spinlock)(&ob->lock);
+		if (ob->dev == dev && ob->bucket == bucket) {
+			ob->do_discards_fast = false;
+			return true;
+		}
+	}
+
+	return false;
+}
+
 enum bch_write_flags;
 int bch2_bucket_alloc_set_trans(struct btree_trans *, struct alloc_request *,
 				struct dev_stripe_state *);


### PR DESCRIPTION
When an open bucket briefly transitions to `BCH_DATA_need_discard` and then gets reused before the open bucket is closed, the fast-discard intent must be cancelled. Otherwise `__bch2_open_bucket_put()` can still enqueue a discard for a bucket that has left `need_discard`, matching the issue koverstreet/bcachefs#1135 failure mode where discard completion sees live `btree` allocation state.

This clears `open_bucket->do_discards_fast` on the legitimate `need_discard -> nonempty` open-bucket transition. The branch is refreshed on current master after `ca944a61e079450f82be88c91e349638c75cf4b6` moved the adjacent bucket state assertions into the current fsck/WARN path, so this PR now only adds the fast-discard cancellation side effect.

Addresses koverstreet/bcachefs#1135.

Validation:
- `git diff --check`
- `scripts/checkpatch.pl --strict --codespell --no-tree --show-types --max-line-length=100` on this diff
- `codex review --base origin/master`
- QEMU: `./build-test-kernel run -k /tmp/bcachefs-best-fixed-stack-ca944 -o /tmp/bcachefs-stack-ca944-discard-qemu tests/fs/bcachefs/replication.ktest device_set_state_rw_offline` (`TEST SUCCESS`, kernel `6.17.0-ktest-02013-gf1629081027b`)
- Included in the refreshed aggregate stack on base `ca944a61e079450f82be88c91e349638c75cf4b6`, aggregate head `f1629081027bed0a5ea3ac8dc129d1771f1397f1`; aggregate `git diff --check`, aggregate checkpatch, and all stack QEMU lanes passed.

Note: I also tried a focused write/truncate/write stress ktest against both patched and unpatched kernels; it passed on both, so I did not include it as a reproducer.
