### PR TITLE
bcachefs: Fix nocow unwritten extent data loss under ENOSPC

### DIFF
--- a/fs/bcachefs/data/io_misc.c
+++ b/fs/bcachefs/data/io_misc.c
@@ -39,8 +39,7 @@ int bch2_extent_fallocate(struct btree_trans *trans,
 	CLASS(disk_reservation, res)(c);
 	struct open_buckets open_buckets = { 0 };
 	unsigned sectors_allocated = 0, new_replicas;
-	bool unwritten = opts.nocow &&
-	    c->sb.version >= bcachefs_metadata_version_unwritten_extents;
+	bool unwritten = false;
 	int ret;
 
 	struct bkey_buf old __cleanup(bch2_bkey_buf_exit);

--- a/fs/bcachefs/data/write.c
+++ b/fs/bcachefs/data/write.c
@@ -1925,7 +1925,7 @@ static bool bch2_extent_is_writeable(struct bch_write_op *op,
 
 	guard(rcu)();
 	extent_for_each_ptr_decode(e, p, entry) {
-		if (crc_is_encoded(p.crc) || p.has_ec)
+		if (crc_is_encoded(p.crc) || p.has_ec || p.ptr.unwritten)
 			return false;
 
 		replicas += !p.ptr.cached


### PR DESCRIPTION
When a nocow file has unwritten extents (from fallocate) and the disk is nearly full, the post-write btree transaction that converts unwritten→written can fail because the journal has no space. The data was already written in-place to the extent's blocks, but the extent key still says "unwritten", so subsequent reads return zeros — silent data loss.

Two fixes:

1. Disable unwritten extents in nocow fallocate (io_misc.c): Use KEY_TYPE_reservation instead, so the first write to a fallocated range goes through COW which atomically allocates+writes+updates metadata in one btree transaction.

2. Reject unwritten extents in nocow write path (write.c): Add p.ptr.unwritten check to bch2_extent_is_writeable(), forcing fallback to COW for any existing unwritten extents. This is a safety net for files created before fix 1.






# bcachefs Nocow Mode Data Corruption Investigation and Fix Report

**Date**: 2026-06-17  
**Fix branch**: `nocow-data-fix` (based on origin/master)  
**Fix commit**: `ed136b808517`

---

## 1. Problem Description

Database file corruption (SQLite WAL) was observed when using bcachefs in nocow mode for VM workloads. The corruption occurred under low disk space conditions, but the user was not aware the disk was nearly full until after a system reboot.

**Key characteristics**:
- Filesystem mounted with nocow enabled (`chattr +C`)
- VM image file pre-allocated via `fallocate`
- Corruption occurred when disk space was running low
- Data was already corrupted after reboot, unrecoverable

---

## 2. Root Cause Analysis

### 2.1 Nocow Write Path Overview

bcachefs's nocow (no copy-on-write) mode allows in-place overwrites of already-allocated data blocks, bypassing the regular COW path:

```
Application DIO write → bch2_write()
  → bch2_nocow_write()
    1. Look up extent (btree transaction)
    2. Check if extent is nocowable (bch2_extent_is_writeable)
    3. Acquire nocow locks (per-bucket)
    4. Submit bio to device (in-place write)
  → bch2_nocow_write_done()
    5. If unwritten extent, perform btree conversion (unwritten → written)
```

### 2.2 How Unwritten Extents Are Created

When `fallocate` pre-allocates space for a nocow file, bcachefs creates **unwritten extents**:

```c
// data/io_misc.c:42-43 (before fix)
bool unwritten = opts.nocow &&
    c->sb.version >= bcachefs_metadata_version_unwritten_extents;
```

- Real disk blocks are allocated (sectors reserved)
- Extent pointers are tagged with `ptr->unwritten = true`
- Meaning: "blocks allocated but contents not yet initialized"

### 2.3 The Data Loss Chain

```
┌─────────────────────────────────────────────────────────────┐
│ 1. fallocate creates VM image                                │
│    → File contains many unwritten extents                    │
│      (blocks allocated, flagged as not-yet-written)          │
├─────────────────────────────────────────────────────────────┤
│ 2. QEMU nocow DIO write                                      │
│    → bch2_nocow_write() finds unwritten extent               │
│    → Data written in-place to allocated blocks               │
│    → BCH_WRITE_convert_unwritten flag set                    │
├─────────────────────────────────────────────────────────────┤
│ 3. Post-write: unwritten → written conversion                │
│    → bch2_nocow_write_convert_unwritten()                    │
│    → Requires a btree transaction (needs journal space)      │
│    → Uses BCH_TRANS_COMMIT_no_enospc to skip pre-check      │
├─────────────────────────────────────────────────────────────┤
│ 4. Disk full: journal cannot reclaim                         │
│    → Btree transaction fails (journal truly out of space)    │
│    → Extent remains "unwritten"                              │
│    → op->error set, but data already on disk                 │
├─────────────────────────────────────────────────────────────┤
│ 5. Subsequent reads                                          │
│    → Kernel sees extent flagged as "unwritten"               │
│    → Returns zeros instead of actual written data            │
│    → Silent data loss!                                       │
└─────────────────────────────────────────────────────────────┘
```

### 2.4 Why BCH_TRANS_COMMIT_no_enospc Is Insufficient

The `BCH_TRANS_COMMIT_no_enospc` flag bypasses **disk space pre-checks** (disk reservation), but does **not guarantee** the btree transaction will succeed:

| Check | Skipped by no_enospc? | Notes |
|-------|----------------------|-------|
| Disk space pre-check | Yes | BCH_DISK_RESERVATION_NOFAIL |
| Btree interior update space | Yes | Same |
| **Journal space** | **No** | **Journal full still fails** |
| Btree node split | No | Requires additional space |
| Key cache pressure | No | Watermark check |

When the disk is completely full, journal reclaim cannot free space (flushing btree nodes requires allocating new buckets, but no space is available), causing the journal to exhaust. Even with `no_enospc`, the btree transaction fails.

### 2.5 No Background Recovery Mechanism

The reconcile subsystem explicitly **skips** unwritten extent conversion:

```c
// data/reconcile/trigger.c:560-564
if (unwritten) {
    BCH_RECONCILE_background_compression cleared;
    BCH_RECONCILE_data_checksum cleared;
}
// Line 574: EC reconcile only triggered when !unwritten
```

The unwritten → written conversion is a **one-shot foreground operation** with no background retry. Once it fails, the extent permanently remains in the unwritten state.

---

## 3. Nocow Space Ambiguity

In nocow mode, the boundary of "disk space sufficient" is critically ambiguous:

| Operation | Needs new blocks | Needs journal space | Result when disk full |
|-----------|-----------------|--------------------|-----------------------|
| Nocow overwrite (written extent) | No | No | **Succeeds** |
| Nocow overwrite (unwritten extent) | No | **Yes** | **May fail** |
| COW write | Yes | Yes | Fails (ENOSPC) |
| Truncate / metadata update | No | Yes | May fail |

**Key problem**: `statfs` reports free space identically regardless of nocow mode. Users see "space available" but the journal may be unreclaimable, causing unwritten extent conversion failures.

---

## 4. Fix

### 4.1 Fix 1: Disable Unwritten Extents in Nocow Fallocate

**File**: `data/io_misc.c:42`

**Change**:
```c
// Before
bool unwritten = opts.nocow &&
    c->sb.version >= bcachefs_metadata_version_unwritten_extents;

// After
bool unwritten = false;
```

**Rationale**:
- Fallocate now creates `KEY_TYPE_reservation` (lightweight space reservation, no actual blocks allocated)
- On subsequent write, the nocow path rejects this key type (`k.k->type != KEY_TYPE_extent`)
- Falls back to COW, which atomically: allocates blocks + writes data + updates metadata (one btree transaction)
- After the first write, the extent becomes "written" and all subsequent overwrites use the nocow fast path

**Tradeoff**: First write to a fallocated range uses COW (one-time cost). All subsequent overwrites use nocow.

### 4.2 Fix 2: Make Nocow Reject Unwritten Extents

**File**: `data/write.c:1928`

**Change**:
```c
// Before
if (crc_is_encoded(p.crc) || p.has_ec)
    return false;

// After
if (crc_is_encoded(p.crc) || p.has_ec || p.ptr.unwritten)
    return false;
```

**Rationale**:
- Safety net: for existing unwritten extents (from before Fix 1), nocow rejects them and falls back to COW
- COW correctly handles unwritten extents: allocates new blocks, writes data, completes all updates in one atomic btree transaction
- If journal space is insufficient, COW fails at the allocation stage with ENOSPC — no data is written before metadata can be committed

### 4.3 Post-Fix Write Path

```
Application DIO write → bch2_write()
  → bch2_nocow_write()
    → bch2_extent_is_writeable()
      → unwritten extent? → false (Fix 2 new check)
      → reservation key?  → false (wrong key type)
      → written extent?   → true (normal nocow overwrite)
    → In-place write (no post-write btree conversion needed)
    → Complete (no atomicity issue)

  → COW fallback (unwritten / reservation / non-nocowable extents)
    → Allocate blocks + write data + update btree (atomic transaction)
    → If disk full: fails at allocation stage with ENOSPC
    → No "data written but metadata not updated" intermediate state
```

---

## 5. Code Changes

```
Branch: nocow-data-fix (based on origin/master)
Commit: ed136b808517

 fs/bcachefs/data/io_misc.c | 3 +--   # Fix 1: Disable unwritten extents
 fs/bcachefs/data/write.c   | 2 +-    # Fix 2: Nocow rejects unwritten
 2 files changed, 2 insertions(+), 3 deletions(-)
```

### 5.1 data/io_misc.c

```diff
-       bool unwritten = opts.nocow &&
-           c->sb.version >= bcachefs_metadata_version_unwritten_extents;
+       bool unwritten = false;
```

### 5.2 data/write.c

```diff
-               if (crc_is_encoded(p.crc) || p.has_ec)
+               if (crc_is_encoded(p.crc) || p.has_ec || p.ptr.unwritten)
```

---

## 6. Additional Audit Findings

A comprehensive audit of the original nocow write path was conducted. **No other data corruption risks were identified**:

| Audit Item | Verdict | Reason |
|------------|---------|--------|
| Partial nocow write data loss | Safe | `BCH_WRITE_submitted` flag only set when bio fully fits extent; split does not set it; COW fallback correctly handles remaining bio |
| Nocow vs truncate race | Safe | VFS `inode_dio_begin`/`inode_dio_wait` properly serializes |
| Nocow vs copygc race | Safe | Bucket generation check catches stale pointers, falls back to COW |
| O_DSYNC flush ordering | Safe | `devs_need_flush` set in bio endio, consumed by flush after all bios complete |
| `bch2_extent_is_writeable` completeness | Safe | Correctly rejects reflink / compressed / EC / insufficient replicas |
| Page cache vs DIO coherency | Safe | `bch2_pagecache_block_get` blocks concurrent mmap reads |

---

## 7. Recommendations

### 7.1 Immediate Actions

1. **Apply this fix**: Switch to `nocow-data-fix` branch, build and install
2. **Monitor disk space**: Maintain at least 10% free space using `df -h`
3. **Recover corrupted files**: Restore SQLite WAL files from backup

### 7.2 Long-Term Guidance

1. **VM image creation**: Use `dd if=/dev/zero` instead of `fallocate` for nocow images to create written extents directly
2. **Monitor journal state**: Watch `/sys/fs/bcachefs/<uuid>/journal_*` sysfs attributes for pressure indicators
3. **Set up space alerts**: Use monitoring tools to alert when free space drops below threshold

### 7.3 VM Image Creation Comparison

| Method | Extent type | Nocow safe | Notes |
|--------|------------|-----------|-------|
| `fallocate -l 100G img` | unwritten (pre-fix) / reservation (post-fix) | Safe after fix | Recommended |
| `dd if=/dev/zero of=img bs=1M count=100K` | written | Safe | Writes zeros, nocow from first overwrite |
| `truncate -s 100G img` | hole | Safe | First write goes through COW |
| `qemu-img create -f raw img 100G` | depends on implementation | Varies | Check underlying method |
