### PR TITLE
bcachefs: fix offline write-device mask

### DIFF
--- a/fs/bcachefs/init/dev.c
+++ b/fs/bcachefs/init/dev.c
@@ -1271,7 +1271,7 @@ static int bch2_dev_may_offline(struct bch_fs *c, struct bch_dev *ca, int flags,
 	__clear_bit(ca->dev_idx, new_devs.d);
 
 	struct bch_devs_mask new_rw_devs = c->allocator.rw_devs[0];
-	__clear_bit(ca->dev_idx, new_devs.d);
+	__clear_bit(ca->dev_idx, new_rw_devs.d);
 
 	if (!bch2_can_read_fs_with_devs(c, &new_devs, flags, err) ||
 	    (!c->opts.read_only &&


### PR DESCRIPTION
## Superseded / Correct Target

This closed kernel-tree PR was opened against the wrong split repo. The same Komzpa-authored fix is already present on current `koverstreet/bcachefs-tools` `master` as commit `d59bb77b73` (`bcachefs: fix rw dev mask when checking device offline`), so this PR is historical provenance only.

---

## Summary

`bch2_dev_may_offline()` builds two masks before deciding whether a device can be taken offline:

- `new_devs` for read availability
- `new_rw_devs` for write availability

The write mask was copied from `c->allocator.rw_devs[0]`, but the code cleared the offlined device from `new_devs` a second time instead of clearing `new_rw_devs`. That left the candidate-offline device in the write-availability check.

Clear `new_rw_devs` so `bch2_can_write_fs_with_devs()` evaluates the actual post-offline writable device set.

## Validation

- `git diff --check origin/master...HEAD && git diff --check`
- `make O=/home/kom/tmp/bcachefs-dev-may-offline-rw-mask-build defconfig`
- `./scripts/config --file /home/kom/tmp/bcachefs-dev-may-offline-rw-mask-build/.config -m BCACHEFS_FS`
- `make O=/home/kom/tmp/bcachefs-dev-may-offline-rw-mask-build olddefconfig`
- `make O=/home/kom/tmp/bcachefs-dev-may-offline-rw-mask-build -j32 fs/bcachefs/bcachefs.o`
- `codex review --base origin/master` (clean)

The temporary build directory was removed after validation.

Related to https://github.com/koverstreet/bcachefs/issues/142

