### PR TITLE
bcachefs: guard bch2_backpointer_to_text() against unvalidated keys and NULL fs

### DIFF
--- a/fs/bcachefs/Kconfig
+++ b/fs/bcachefs/Kconfig
@@ -93,3 +93,12 @@ config MEAN_AND_VARIANCE_UNIT_TEST
 	help
 	  This option enables the kunit tests for mean_and_variance module.
 	  If unsure, say N.
+
+config BACKPOINTERS_UNIT_TEST
+	tristate "backpointer unit tests" if !KUNIT_ALL_TESTS
+	depends on KUNIT
+	depends on BCACHEFS_FS
+	default KUNIT_ALL_TESTS
+	help
+	  This option enables the kunit tests for the backpointers module.
+	  If unsure, say N.

--- a/fs/bcachefs/Makefile
+++ b/fs/bcachefs/Makefile
@@ -132,6 +132,7 @@ endif
 
 ifndef BCACHEFS_DKMS
 	obj-$(CONFIG_MEAN_AND_VARIANCE_UNIT_TEST)   += util/mean_and_variance_test.o
+	bcachefs-$(CONFIG_BACKPOINTERS_UNIT_TEST) += alloc/backpointers_test.o
 endif
 
 ifdef BCACHEFS_DKMS

--- a/fs/bcachefs/alloc/backpointers.c
+++ b/fs/bcachefs/alloc/backpointers.c
@@ -52,6 +52,13 @@ fsck_err:
 
 void bch2_backpointer_to_text(struct printbuf *out, struct bch_fs *c, struct bkey_s_c k)
 {
+	/* We may be called on unvalidated keys: */
+	if (k.k->u64s <= BKEY_U64s ||
+	    bkey_val_u64s(k.k) * sizeof(u64) < sizeof(struct bch_backpointer)) {
+		prt_str(out, "(invalid, backpointer value truncated)");
+		return;
+	}
+
 	struct bkey_s_c_backpointer bp = bkey_s_c_to_backpointer(k);
 
 	struct bch_dev *ca;
@@ -65,16 +72,23 @@ void bch2_backpointer_to_text(struct printbuf *out, struct bch_fs *c, struct bke
 
 	if (ca)
 		prt_printf(out, "bucket=%llu:%llu:%u ", bucket.inode, bucket.offset, bucket_offset);
-	else
+	else if (c)
 		prt_printf(out, "sector=%llu:%llu ", bp.k->p.inode, bp.k->p.offset >> c->sb.extent_bp_shift);
+	else
+		prt_printf(out, "pos=%llu:%llu ", bp.k->p.inode, bp.k->p.offset);
 
 	bch2_btree_id_level_to_text(out, bp.v->btree_id, bp.v->level);
 	prt_str(out, " data_type=");
 	bch2_prt_data_type(out, bp.v->data_type);
-	prt_printf(out, " suboffset=%u len=%u gen=%u pos=",
-		   (u32) bp.k->p.offset & ~(~0U << c->sb.extent_bp_shift),
-		   bp.v->bucket_len,
-		   bp.v->bucket_gen);
+	if (c)
+		prt_printf(out, " suboffset=%u len=%u gen=%u pos=",
+			   (u32) bp.k->p.offset & ~(~0U << c->sb.extent_bp_shift),
+			   bp.v->bucket_len,
+			   bp.v->bucket_gen);
+	else
+		prt_printf(out, " len=%u gen=%u pos=",
+			   bp.v->bucket_len,
+			   bp.v->bucket_gen);
 	bch2_bpos_to_text(out, bp.v->pos);
 
 	if (BACKPOINTER_RECONCILE_PHYS(bp.v))

--- a/fs/bcachefs/alloc/backpointers_test.c
+++ b/fs/bcachefs/alloc/backpointers_test.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <kunit/test.h>
+
+#include "bcachefs.h"
+#include "alloc/backpointers.h"
+#include "btree/bkey_types.h"
+#include "util/printbuf.h"
+
+#define BP_VAL_U64s	DIV_ROUND_UP(sizeof(struct bch_backpointer), sizeof(u64))
+
+struct backpointer_test_key {
+	struct bkey_i	k;
+	u64		v[BP_VAL_U64s];
+};
+
+static void backpointer_to_text_truncated_test(struct kunit *test)
+{
+	struct backpointer_test_key buf;
+	struct printbuf out = PRINTBUF;
+
+	/* Truncated key headers and truncated values must print an
+	 * invalid marker, not read past the key: */
+	for (unsigned u64s = 0; u64s < BKEY_U64s + BP_VAL_U64s; u64s++) {
+		memset(&buf, 0, sizeof(buf));
+		buf.k.k.u64s = u64s;
+		buf.k.k.type = KEY_TYPE_backpointer;
+
+		bch2_backpointer_to_text(&out, NULL, bkey_i_to_s_c(&buf.k));
+		KUNIT_EXPECT_NOT_NULL(test, strstr(out.buf, "(invalid"));
+
+		printbuf_reset(&out);
+	}
+
+	printbuf_exit(&out);
+}
+
+static void backpointer_to_text_null_fs_test(struct kunit *test)
+{
+	struct backpointer_test_key buf = {};
+	struct printbuf out = PRINTBUF;
+
+	buf.k.k.u64s = BKEY_U64s + BP_VAL_U64s;
+	buf.k.k.type = KEY_TYPE_backpointer;
+
+	/* We may be called with a NULL fs: */
+	bch2_backpointer_to_text(&out, NULL, bkey_i_to_s_c(&buf.k));
+	KUNIT_EXPECT_NOT_NULL(test, strstr(out.buf, "pos="));
+
+	printbuf_exit(&out);
+}
+
+static struct kunit_case backpointer_test_cases[] = {
+	KUNIT_CASE(backpointer_to_text_truncated_test),
+	KUNIT_CASE(backpointer_to_text_null_fs_test),
+	{}
+};
+
+static struct kunit_suite backpointer_test_suite = {
+	.name		= "backpointer tests",
+	.test_cases	= backpointer_test_cases
+};
+
+kunit_test_suite(backpointer_test_suite);
+
+MODULE_AUTHOR("Matthias Goergens");
+MODULE_DESCRIPTION("bcachefs filesystem backpointer unit tests");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
bch2_backpointer_to_text() can be called on unvalidated keys (the sb
validation error path prints corrupt sections with a NULL fs) — a
truncated key header or value made it read past the key, and a NULL fs
made it dereference c->sb.

Guard the key size before the typed conversion, print an invalid marker
for truncated keys (bkey_val_u64s() underflows when u64s < BKEY_U64s, so
the header length is checked explicitly), and print a plain position
instead of dereferencing c without a filesystem context.

Adds kunit tests for both paths, passing under UML.

Found by fuzzing the offline tools with AFL++/ASAN; reproduced on an
unmodified build with a re-checksummed input.

The same fix for the bcachefs-tools tree is in
https://github.com/koverstreet/bcachefs-tools/pull/876.