### PR TITLE
bcachefs: guard dirent to_text against unvalidated names

### DIFF
--- a/fs/bcachefs/Kconfig
+++ b/fs/bcachefs/Kconfig
@@ -93,3 +93,12 @@ config MEAN_AND_VARIANCE_UNIT_TEST
 	help
 	  This option enables the kunit tests for mean_and_variance module.
 	  If unsure, say N.
+
+config DIRENT_UNIT_TEST
+	tristate "dirent unit tests" if !KUNIT_ALL_TESTS
+	depends on KUNIT
+	depends on BCACHEFS_FS
+	default KUNIT_ALL_TESTS
+	help
+	  This option enables the kunit tests for the dirent module.
+	  If unsure, say N.

--- a/fs/bcachefs/Makefile
+++ b/fs/bcachefs/Makefile
@@ -132,6 +132,7 @@ endif
 
 ifndef BCACHEFS_DKMS
 	obj-$(CONFIG_MEAN_AND_VARIANCE_UNIT_TEST)   += util/mean_and_variance_test.o
+	bcachefs-$(CONFIG_DIRENT_UNIT_TEST)      += fs/dirent_test.o
 endif
 
 ifdef BCACHEFS_DKMS

--- a/fs/bcachefs/fs/dirent.c
+++ b/fs/bcachefs/fs/dirent.c
@@ -209,14 +209,35 @@ fsck_err:
 void bch2_dirent_to_text(struct printbuf *out, struct bch_fs *c, struct bkey_s_c k)
 {
 	struct bkey_s_c_dirent d = bkey_s_c_to_dirent(k);
+
+	/* We may be called on unvalidated keys: */
+	if (k.k->u64s <= BKEY_U64s ||
+	    bkey_val_u64s(k.k) * sizeof(u64) < sizeof(struct bch_dirent)) {
+		prt_str(out, "(invalid, dirent value truncated)");
+		return;
+	}
+
 	struct qstr d_name = bch2_dirent_get_name(d);
+
+	if (d_name.len > bkey_val_bytes(k.k) ||
+	    d_name.name - (const u8 *) d.v + d_name.len > bkey_val_bytes(k.k)) {
+		prt_str(out, "(invalid, dirent name overruns value)");
+		return;
+	}
 
 	prt_bytes(out, d_name.name, d_name.len);
 
 	if (d.v->d_casefold) {
 		prt_str(out, " (casefold ");
-		struct qstr d_name = bch2_dirent_get_lookup_name(d);
-		prt_bytes(out, d_name.name, d_name.len);
+		struct qstr d_lookup_name = bch2_dirent_get_lookup_name(d);
+
+		if (d_lookup_name.len > bkey_val_bytes(k.k) ||
+		    d_lookup_name.name - (const u8 *) d.v + d_lookup_name.len >
+		    bkey_val_bytes(k.k)) {
+			prt_str(out, "(invalid, lookup name overruns value)");
+		} else {
+			prt_bytes(out, d_lookup_name.name, d_lookup_name.len);
+		}
 		prt_char(out, ')');
 	}
 

--- a/fs/bcachefs/fs/dirent_test.c
+++ b/fs/bcachefs/fs/dirent_test.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <kunit/test.h>
+
+#include "bcachefs.h"
+#include "fs/dirent.h"
+#include "btree/bkey_types.h"
+#include "util/printbuf.h"
+
+/*
+ * Kernel layout notes (measured on x86-64, see kunit run logs): struct
+ * bch_val is zero-sized, so value fields start at value offset 0 —
+ * d_inum@0, the d_type/d_casefold byte@8 (d_casefold is bit 7),
+ * d_pad@9, d_name_len@11, d_cf_name_len@13, d_names@15,
+ * offsetof(d_name) == 9, sizeof(struct bch_dirent) == 16.
+ */
+struct dirent_test_key {
+	struct bkey_i	k;
+	u64		v[4];
+};
+
+static void dirent_to_text_truncated_test(struct kunit *test)
+{
+	struct dirent_test_key buf;
+	struct printbuf out = PRINTBUF;
+
+	/* Truncated key headers and truncated values must print an
+	 * invalid marker, not read past the key: */
+	for (unsigned u64s = 0; u64s < BKEY_U64s + 3; u64s++) {
+		memset(&buf, 0, sizeof(buf));
+		buf.k.k.u64s = u64s;
+		buf.k.k.type = KEY_TYPE_dirent;
+
+		bch2_dirent_to_text(&out, NULL, bkey_i_to_s_c(&buf.k));
+		KUNIT_EXPECT_NOT_NULL_MSG(test, strstr(out.buf, "(invalid"), out.buf ?: "(null)");
+
+		printbuf_reset(&out);
+	}
+
+	printbuf_exit(&out);
+}
+
+static void dirent_to_text_underflowed_name_test(struct kunit *test)
+{
+	struct dirent_test_key buf = {};
+	struct printbuf out = PRINTBUF;
+
+	/* Full-size value, but the last value u64 is all zero: the name
+	 * length computation underflows (val_bytes 16 - offsetof(d_name)
+	 * 9 - 8 trailing nuls) and the guard must catch the wrapped
+	 * length: */
+	buf.k.k.u64s = BKEY_U64s + 2;
+	buf.k.k.type = KEY_TYPE_dirent;
+
+	bch2_dirent_to_text(&out, NULL, bkey_i_to_s_c(&buf.k));
+	KUNIT_EXPECT_NOT_NULL_MSG(test, strstr(out.buf, "(invalid"), out.buf ?: "(null)");
+
+	printbuf_exit(&out);
+}
+
+static void dirent_to_text_casefold_overrun_test(struct kunit *test)
+{
+	struct dirent_test_key buf = {};
+	struct bch_dirent *d = (void *) buf.v;
+	struct printbuf out = PRINTBUF;
+
+	/* d_name_len fits, but the casefold lookup name is inflated
+	 * (d_cf_name_len = 0xffff) and must be caught: */
+	buf.k.k.u64s = BKEY_U64s + 2;
+	buf.k.k.type = KEY_TYPE_dirent;
+	d->d_casefold = 1;
+	d->d_cf_name_block.d_name_len = cpu_to_le16(1);
+	d->d_cf_name_block.d_cf_name_len = cpu_to_le16(0xffff);
+	d->d_cf_name_block.d_names[0] = 'a';
+
+	bch2_dirent_to_text(&out, NULL, bkey_i_to_s_c(&buf.k));
+	KUNIT_EXPECT_NOT_NULL_MSG(test, strstr(out.buf, "(invalid"), out.buf ?: "(null)");
+
+	printbuf_exit(&out);
+}
+
+static struct kunit_case dirent_test_cases[] = {
+	KUNIT_CASE(dirent_to_text_truncated_test),
+	KUNIT_CASE(dirent_to_text_underflowed_name_test),
+	KUNIT_CASE(dirent_to_text_casefold_overrun_test),
+	{}
+};
+
+static struct kunit_suite dirent_test_suite = {
+	.name		= "dirent tests",
+	.test_cases	= dirent_test_cases
+};
+
+kunit_test_suite(dirent_test_suite);
+
+MODULE_AUTHOR("Matthias Goergens");
+MODULE_DESCRIPTION("bcachefs filesystem dirent unit tests");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
bch2_dirent_to_text() may be called on unvalidated keys: the sb
validation error path prints a corrupt clean section's journal entries,
and a dirent key with a truncated value or an inflated name length read
past the key in prt_bytes().

Return early with an invalid marker for truncated keys, and check the
name and lookup-name extents against the value bounds before printing.
The extent guards check the length before computing the sum, so the sum
cannot wrap (qstr.len is u32 and bch2_dirent_name_bytes() can underflow).

Adds kunit tests for the truncated, underflowed-name, and casefold
overrun paths, passing under UML.

Found by fuzzing the offline tools with AFL++/ASAN.

The bcachefs-tools tree has the same fix in
https://github.com/koverstreet/bcachefs-tools/pull/877.